### PR TITLE
Add CLI support with auto-auth helper command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -135,6 +135,12 @@
       "integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg==",
       "dev": true
     },
+    "@types/yargs": {
+      "version": "12.0.10",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.10.tgz",
+      "integrity": "sha512-WsVzTPshvCSbHThUduGGxbmnwcpkgSctHGHTqzWyFg4lYAuV5qXlyFPOsP3OWqCINfmg/8VXP+zJaa4OxEsBQQ==",
+      "dev": true
+    },
     "ajv": {
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
@@ -145,6 +151,11 @@
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       }
+    },
+    "ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
     },
     "argparse": {
       "version": "1.0.10",
@@ -216,6 +227,11 @@
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
+    "camelcase": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
+      "integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ=="
+    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -232,6 +248,32 @@
         "tldjs": "^2.3.1",
         "tough-cookie": "^3.0.1"
       }
+    },
+    "cliui": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+      "requires": {
+        "string-width": "^2.1.1",
+        "strip-ansi": "^4.0.0",
+        "wrap-ansi": "^2.0.0"
+      },
+      "dependencies": {
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        }
+      }
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "color": {
       "version": "3.0.0",
@@ -296,6 +338,18 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "requires": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -311,6 +365,11 @@
       "requires": {
         "ms": "^2.1.1"
       }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -344,6 +403,11 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+    },
     "enabled": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
@@ -352,10 +416,32 @@
         "env-variable": "0.0.x"
       }
     },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
     "env-variable": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.5.tgz",
       "integrity": "sha512-zoB603vQReOFvTg5xMl9I1P2PnHsHQQKTEowsKKD7nseUfJq6UWzK+4YtlWUO1nhiQUxe6XMkk+JleSZD1NZFA=="
+    },
+    "execa": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "requires": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      }
     },
     "extend": {
       "version": "3.0.2",
@@ -387,6 +473,14 @@
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
       "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg=="
     },
+    "find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "requires": {
+        "locate-path": "^3.0.0"
+      }
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -406,11 +500,23 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-      "optional": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
         "universalify": "^0.1.0"
+      }
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+    },
+    "get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "requires": {
+        "pump": "^3.0.0"
       }
     },
     "getpass": {
@@ -424,8 +530,7 @@
     "graceful-fs": {
       "version": "4.1.15",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
-      "optional": true
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
     },
     "har-schema": {
       "version": "2.0.0",
@@ -456,10 +561,20 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
+    "invert-kv": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
+    },
     "is-arrayish": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
     },
     "is-stream": {
       "version": "1.1.0",
@@ -475,6 +590,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isstream": {
       "version": "0.1.2",
@@ -505,7 +625,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "optional": true,
       "requires": {
         "graceful-fs": "^4.1.6"
       }
@@ -565,6 +684,23 @@
         "colornames": "^1.1.1"
       }
     },
+    "lcid": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+      "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+      "requires": {
+        "invert-kv": "^2.0.0"
+      }
+    },
+    "locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "requires": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      }
+    },
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
@@ -622,6 +758,14 @@
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
+    "map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "requires": {
+        "p-defer": "^1.0.0"
+      }
+    },
     "mdns": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/mdns/-/mdns-2.4.0.tgz",
@@ -629,6 +773,16 @@
       "requires": {
         "bindings": "~1.2.1",
         "nan": "^2.10.0"
+      }
+    },
+    "mem": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+      "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+      "requires": {
+        "map-age-cleaner": "^0.1.1",
+        "mimic-fn": "^2.0.0",
+        "p-is-promise": "^2.0.0"
       }
     },
     "mime-db": {
@@ -644,6 +798,11 @@
         "mime-db": "~1.38.0"
       }
     },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+    },
     "ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
@@ -653,6 +812,11 @@
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.1.tgz",
       "integrity": "sha512-I6YB/YEuDeUZMmhscXKxGgZlFnhsn5y0hgOZBadkzfTRrZBtJDZeg6eQf7PYMIEclwmorTKK8GztsyOUSVBREA=="
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "nodecastor": {
       "version": "github:dhleong/nodecastor#e18189c2d5e198dc0d59d4a55d4fa8a41f43ba84",
@@ -666,15 +830,92 @@
         "winston": "^3.2.1"
       }
     },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "requires": {
+        "path-key": "^2.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
     "one-time": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/one-time/-/one-time-0.0.4.tgz",
       "integrity": "sha1-+M33eISCb+Tf+T46nMN7HkSAdC4="
+    },
+    "os-locale": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+      "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+      "requires": {
+        "execa": "^1.0.0",
+        "lcid": "^2.0.0",
+        "mem": "^4.0.0"
+      }
+    },
+    "p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
+    "p-is-promise": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
+      "integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg=="
+    },
+    "p-limit": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+      "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "requires": {
+        "p-limit": "^2.0.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+    },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "performance-now": {
       "version": "2.1.0",
@@ -722,6 +963,15 @@
       "version": "1.1.31",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
       "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "punycode": {
       "version": "2.1.1",
@@ -795,6 +1045,16 @@
         "tough-cookie": "^2.3.3"
       }
     },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -809,6 +1069,29 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
       "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "simple-swizzle": {
       "version": "0.2.2",
@@ -849,6 +1132,31 @@
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
+    "string-width": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "requires": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
     "string_decoder": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
@@ -856,6 +1164,19 @@
       "requires": {
         "safe-buffer": "~5.1.0"
       }
+    },
+    "strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "requires": {
+        "ansi-regex": "^3.0.0"
+      }
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "text-hex": {
       "version": "1.0.0",
@@ -905,8 +1226,7 @@
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "optional": true
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "uri-js": {
       "version": "4.2.2",
@@ -935,6 +1255,19 @@
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
       }
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "winston": {
       "version": "3.2.1",
@@ -983,6 +1316,85 @@
             "safe-buffer": "~5.1.0"
           }
         }
+      }
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "requires": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "y18n": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+    },
+    "yargs": {
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.2.tgz",
+      "integrity": "sha512-WyEoxgyTD3w5XRpAQNYUB9ycVH/PQrToaTXdYXRdOXvEy1l19br+VJsc0vcO8PTGg5ro/l/GY7F/JMEBmI0BxA==",
+      "requires": {
+        "cliui": "^4.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "os-locale": "^3.1.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.0.0"
+      }
+    },
+    "yargs-parser": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.0.0.tgz",
+      "integrity": "sha512-w2LXjoL8oRdRQN+hOyppuXs+V/fVAYtpcrRxZuF7Kt/Oc+Jr2uAcVntaUTNT6w5ihoWfFDpNY8CPx1QskxZ/pw==",
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
       }
     },
     "youtubish": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "babbling",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -74,6 +74,15 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
       "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/fs-extra": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.5.tgz",
+      "integrity": "sha512-w7iqhDH9mN8eLClQOYTkhdYUOSpp25eXxfc6VbFOGtzxW34JcvctH2bKjj4jD4++z4R5iO5D+pg48W2e03I65A==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -211,6 +220,18 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "chromagnon": {
+      "version": "1.0.0",
+      "optional": true,
+      "requires": {
+        "better-sqlite3": "^5.4.0",
+        "keytar": "^4.4.1",
+        "leveldown": "^5.0.0",
+        "levelup": "^4.0.1",
+        "tldjs": "^2.3.1",
+        "tough-cookie": "^3.0.1"
+      }
     },
     "color": {
       "version": "3.0.0",
@@ -381,6 +402,17 @@
         "mime-types": "^2.1.12"
       }
     },
+    "fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "optional": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -388,6 +420,12 @@
       "requires": {
         "assert-plus": "^1.0.0"
       }
+    },
+    "graceful-fs": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+      "optional": true
     },
     "har-schema": {
       "version": "2.0.0",
@@ -462,6 +500,15 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "optional": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "jsonwebtoken": {
       "version": "8.5.1",
@@ -854,6 +901,12 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.4000.tgz",
       "integrity": "sha512-jjOcCZvpkl2+z7JFn0yBOoLQyLoIkNZAs/fYJkUG6VKy6zLPHJGfQJYFHzibB6GJaF/8QrcECtlQ5cpvRHSMEA==",
       "dev": true
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "optional": true
     },
     "uri-js": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "homepage": "https://github.com/dhleong/babbling#readme",
   "dependencies": {
     "debug": "^4.1.1",
+    "fs-extra": "^7.0.1",
     "jsonwebtoken": "^8.5.1",
     "nodecastor": "dhleong/nodecastor#e18189c",
     "request": "^2.88.0",
@@ -40,9 +41,13 @@
   },
   "devDependencies": {
     "@types/debug": "^4.1.3",
+    "@types/fs-extra": "^5.0.5",
     "@types/jsonwebtoken": "^8.3.2",
     "@types/node": "^11.12.0",
     "@types/request-promise-native": "^1.0.15",
     "typescript": "^3.3.4000"
+  },
+  "optionalDependencies": {
+    "chromagnon": "file://~/git/chromagnon"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "files": [
     "/dist"
   ],
+  "bin": {
+    "babbling": "./dist/cli/index.js"
+  },
   "scripts": {
     "build": "tsc -p .",
     "check": "npm run lint && npm run build",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
     "typescript": "^3.3.4000"
   },
   "optionalDependencies": {
-    "chromagnon": "file:~/git/chromagnon"
+    "chromagnon": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "nodecastor": "dhleong/nodecastor#e18189c",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.7",
+    "yargs": "^13.2.2",
     "youtubish": "^1.0.2"
   },
   "devDependencies": {
@@ -45,9 +46,10 @@
     "@types/jsonwebtoken": "^8.3.2",
     "@types/node": "^11.12.0",
     "@types/request-promise-native": "^1.0.15",
+    "@types/yargs": "^12.0.10",
     "typescript": "^3.3.4000"
   },
   "optionalDependencies": {
-    "chromagnon": "file://~/git/chromagnon"
+    "chromagnon": "file:~/git/chromagnon"
   }
 }

--- a/src/apps/hbogo/config.ts
+++ b/src/apps/hbogo/config.ts
@@ -1,0 +1,26 @@
+import { CookieExtractor, LocalStorageExtractor } from "chromagnon";
+
+import { IConfigurable } from "../../cli/model";
+
+export interface IHboGoOpts {
+    /**
+     * The bearer token, as found in the Authorization header
+     * for a request to `https://comet.api.hbo.com/content`
+     */
+    token: string;
+}
+
+export class HboGoConfigurable implements IConfigurable<IHboGoOpts> {
+    public async extractConfig(
+        cookies: CookieExtractor,
+        storage: LocalStorageExtractor,
+    ) {
+        for await (const { key, value } of storage.readAll("https://play.hbogo.com")) {
+            if (key.includes("LoginInfo.user")) {
+                const entry = JSON.parse(value);
+                const token = entry.accessToken;
+                return { token };
+            }
+        }
+    }
+}

--- a/src/apps/hbogo/index.ts
+++ b/src/apps/hbogo/index.ts
@@ -8,18 +8,12 @@ import { BaseApp } from "../base";
 import { awaitMessageOfType } from "../util";
 
 import { HboGoApi } from "./api";
+import { HboGoConfigurable, IHboGoOpts } from "./config";
+export { IHboGoOpts } from "./config";
 
 const APP_ID = "144BDEF0";
 const HBO_GO_NS = "urn:x-cast:hbogo";
 const MEDIA_NS = "urn:x-cast:com.google.cast.media";
-
-export interface IHboGoOpts {
-    /**
-     * The bearer token, as found in the Authorization header
-     * for a request to `https://comet.api.hbo.com/content`
-     */
-    token: string;
-}
 
 export interface IHboGoPlayOptions {
     /** Eg "ENG" */
@@ -33,6 +27,8 @@ export interface IHboGoPlayOptions {
 }
 
 export class HboGoApp extends BaseApp {
+
+    public static configurable = new HboGoConfigurable();
 
     public static ownsUrl(url: string) {
         return url.includes("play.hbogo.com");

--- a/src/apps/hulu.ts
+++ b/src/apps/hulu.ts
@@ -6,6 +6,7 @@ const debug = _debug("babbling:hulu");
 
 import { ICastSession, IDevice } from "nodecastor";
 import { IApp, IAppConstructor } from "../app";
+import { CookiesConfigurable } from "../cli/configurables";
 import { BaseApp } from "./base";
 import { awaitMessageOfType } from "./util";
 
@@ -55,6 +56,8 @@ function seemsLikeValidUUID(uuid: string) {
 }
 
 export class HuluApp extends BaseApp {
+
+    public static configurable = new CookiesConfigurable<IHuluOpts>("https://www.hulu.com");
 
     public static ownsUrl(url: string) {
         return url.includes("hulu.com");

--- a/src/apps/youtube/config.ts
+++ b/src/apps/youtube/config.ts
@@ -1,0 +1,58 @@
+import { CookieExtractor, LocalStorageExtractor } from "chromagnon";
+import { ICreds } from "youtubish";
+
+import { CookiesConfigurable } from "../../cli/configurables";
+import { IConfigurable } from "../../cli/model";
+
+export interface IPlaylistCache {
+    [id: string]: any;
+}
+
+export interface IYoutubeOpts {
+    /**
+     * A string of cookies as might be retrieved from the "copy as
+     * cURL" from any request on youtube.com in Chrome's network
+     * inspector
+     */
+    cookies?: string;
+
+    /**
+     * Credentials from Youtubish
+     */
+    youtubish?: ICreds;
+
+    /**
+     * Optional cache storage for playlist data, when youtubish
+     * credentials are provided for resuming playlists. If not
+     * provided, playlists will be fetched for each request.
+     *
+     * It is recommended to use the cache for long-running
+     * processes
+     */
+    playlistsCache?: IPlaylistCache;
+
+    /**
+     * The name of the "device" to show when we connect to the
+     * Chromecast. It will be rendered simply as "<deviceName>" at the
+     * top of the screen, or "<owner>'s <deviceName> has joined" if
+     * `cookies` is provided
+     */
+    deviceName?: string;
+}
+
+const baseConfigurable = new CookiesConfigurable("https://www.youtube.com");
+
+export class YoutubeConfigurable implements IConfigurable<IYoutubeOpts> {
+    public async extractConfig(
+        cookies: CookieExtractor,
+        storage: LocalStorageExtractor,
+    ) {
+        const base = await baseConfigurable.extractConfig(cookies, storage);
+        if (!base || !base.cookies) return;
+
+        return {
+            cookies: base.cookies,
+            youtubish: base as { cookies: string },
+        };
+    }
+}

--- a/src/apps/youtube/index.ts
+++ b/src/apps/youtube/index.ts
@@ -11,9 +11,12 @@ const debug = _debug("babbling:youtube");
 import { ICastSession, IDevice } from "nodecastor";
 import { ICreds, WatchHistory, YoutubePlaylist } from "youtubish";
 
-import { IApp, IAppConstructor, IPlayableOptions } from "../app";
-import { BaseApp } from "./base";
-import { awaitMessageOfType } from "./util";
+import { IApp, IAppConstructor, IPlayableOptions } from "../../app";
+import { BaseApp } from "../base";
+import { awaitMessageOfType } from "../util";
+import { IPlaylistCache, IYoutubeOpts, YoutubeConfigurable } from "./config";
+
+export { IYoutubeOpts } from "./config";
 
 const APP_ID = "233637DE";
 const MDX_NS = "urn:x-cast:com.google.youtube.mdx";
@@ -62,43 +65,9 @@ async function getMdxScreenId(session: ICastSession) {
     return status.data.screenId;
 }
 
-export interface IPlaylistCache {
-    [id: string]: any;
-}
-
-export interface IYoutubeOpts {
-    /**
-     * A string of cookies as might be retrieved from the "copy as
-     * cURL" from any request on youtube.com in Chrome's network
-     * inspector
-     */
-    cookies?: string;
-
-    /**
-     * Credentials from Youtubish
-     */
-    youtubish?: ICreds;
-
-    /**
-     * Optional cache storage for playlist data, when youtubish
-     * credentials are provided for resuming playlists. If not
-     * provided, playlists will be fetched for each request.
-     *
-     * It is recommended to use the cache for long-running
-     * processes
-     */
-    playlistsCache?: IPlaylistCache;
-
-    /**
-     * The name of the "device" to show when we connect to the
-     * Chromecast. It will be rendered simply as "<deviceName>" at the
-     * top of the screen, or "<owner>'s <deviceName> has joined" if
-     * `cookies` is provided
-     */
-    deviceName?: string;
-}
-
 export class YoutubeApp extends BaseApp {
+
+    public static configurable = new YoutubeConfigurable();
 
     public static ownsUrl(url: string) {
         return url.includes("youtube.com") || url.includes("youtu.be");

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -1,0 +1,28 @@
+import { Argv } from "yargs";
+
+import { DEFAULT_CONFIG_PATH } from "./config";
+
+export function withConfig<T>(args: Argv<T>) {
+    return args.option("config", {
+        alias: "c",
+        config: true,
+        default: DEFAULT_CONFIG_PATH,
+        describe: `Config file path`,
+        type: "string",
+    });
+}
+
+export function withKey<T>(args: Argv<T>) {
+    return args.positional("key", {
+        choice: ["device"],
+        describe: `Config key`,
+        type: "string",
+    }).demand("key");
+}
+
+export function withValue<T>(args: Argv<T>) {
+    return args.positional("value", {
+        describe: `Config key`,
+        type: "string",
+    });
+}

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -1,0 +1,17 @@
+// tslint:disable no-console
+
+export async function main(args: any[]) {
+    let canConfigure = false;
+    try {
+        require("chromagnon");
+        canConfigure = true;
+    } catch (e) {
+        /* ignore */
+    }
+
+    if (canConfigure) {
+        const { default: configure } = require("./commands/config");
+        console.log(configure);
+        await configure();
+    }
+}

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -1,17 +1,53 @@
 // tslint:disable no-console
 
-export async function main(args: any[]) {
-    let canConfigure = false;
-    try {
-        require("chromagnon");
-        canConfigure = true;
-    } catch (e) {
-        /* ignore */
-    }
+import yargs from "yargs";
 
-    if (canConfigure) {
-        const { default: configure } = require("./commands/config");
-        console.log(configure);
-        await configure();
-    }
+import cast from "./commands/cast";
+
+let canConfigure = false;
+try {
+    // tslint:disable-next-line no-var-requires
+    require("chromagnon");
+    canConfigure = true;
+} catch (e) {
+    /* ignore */
+}
+
+const parser = yargs;
+
+parser.command(
+    "cast <url>", `Cast a video by URL`, args => {
+        return args.positional("url", {
+            describe: "The URL to play",
+            type: "string",
+        }).demand("url")
+            .option("device", {
+                alias: "d",
+                desc: "The name of the Chromecast device",
+                required: true,
+                type: "string",
+            });
+    }, cast,
+);
+
+if (canConfigure) {
+    parser.command(
+        "autoconfig", `Automatically configure available apps`, {
+            // no command-specific config
+        }, async argv => {
+            // chromagnon is a huge dependency, and installs don't need
+            // to require it since it's just for config, so we lazily
+            // import the dependency in case it's not available
+            const { default: configure } = require("./commands/config");
+            console.log(configure);
+            await configure();
+        },
+    );
+}
+
+parser.help()
+    .demandCommand(1);
+
+export async function main(args: any[]) {
+    parser.parse(args.slice(2));
 }

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -2,13 +2,15 @@
 
 import yargs from "yargs";
 
+import { withConfig, withKey, withValue } from "./args";
 import cast from "./commands/cast";
+import { config, unconfig } from "./commands/config";
 
-let canConfigure = false;
+let canAutoConfigure = false;
 try {
     // tslint:disable-next-line no-var-requires
     require("chromagnon");
-    canConfigure = true;
+    canAutoConfigure = true;
 } catch (e) {
     /* ignore */
 }
@@ -17,30 +19,44 @@ const parser = yargs;
 
 parser.command(
     "cast <url>", `Cast a video by URL`, args => {
-        return args.positional("url", {
+        return withConfig(args).positional("url", {
             describe: "The URL to play",
             type: "string",
         }).demand("url")
             .option("device", {
                 alias: "d",
-                desc: "The name of the Chromecast device",
-                required: true,
+                demandOption: true,
+                desc: "The name of the Chromecast device to cast to",
                 type: "string",
             });
     }, cast,
 );
 
-if (canConfigure) {
+parser.command(
+    "config <key> [value]", `Configure (or view) default options`, args => {
+        return withConfig(withValue(withKey(args)));
+    }, async argv => {
+        await config(argv.config, argv.key, argv.value);
+    },
+);
+parser.command(
+    "unconfig <key>", `Remove a configured key`, args => {
+        return withConfig(withKey(args));
+    }, async argv => {
+        await unconfig(argv.config, argv.key);
+    },
+);
+
+if (canAutoConfigure) {
     parser.command(
-        "autoconfig", `Automatically configure available apps`, {
+        "auto-auth", `Automatically authenticate available apps`, {
             // no command-specific config
         }, async argv => {
             // chromagnon is a huge dependency, and installs don't need
             // to require it since it's just for config, so we lazily
             // import the dependency in case it's not available
-            const { default: configure } = require("./commands/config");
-            console.log(configure);
-            await configure();
+            const { default: authenticate } = require("./commands/auth");
+            await authenticate();
         },
     );
 }

--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -1,0 +1,41 @@
+// tslint:disable no-console
+
+import { consoleWrite, prompt } from "./util";
+
+import { ConfigExtractor, DEFAULT_CONFIG_PATH } from "../config";
+import { writeConfig } from "./config";
+
+export default async function authenticate() {
+    consoleWrite(`
+This process will attempt to extract authentication for as many Apps as
+possible from Chrome. You should close Chrome now for this to complete
+successfully.
+
+On macOS you will be prompted to enter a password so we can decrypt
+cookies for some apps.
+    `);
+
+    await prompt("\nPress enter to continue");
+
+    const extractor = new ConfigExtractor();
+    try {
+        const config = await extractor.extract();
+
+        consoleWrite(`Extracted auth:`);
+        console.log(config);
+
+        await writeConfig(DEFAULT_CONFIG_PATH, config);
+        consoleWrite(`
+Wrote config to: ${DEFAULT_CONFIG_PATH}
+        `);
+
+    } catch (e) {
+        consoleWrite(`
+Unable to complete authentication extraction:
+
+    ${e}
+
+You may need to quit Chrome before trying again.
+        `);
+    }
+}

--- a/src/cli/commands/cast.ts
+++ b/src/cli/commands/cast.ts
@@ -1,8 +1,14 @@
 import { ChromecastDevice } from "../../device";
 import { PlayerBuilder } from "../../player";
 
-export default async function cast(opts: {device: string, url: string}) {
-    const builder = await PlayerBuilder.autoInflate();
+export interface ICastOpts {
+    config: string;
+    device: string;
+    url: string;
+}
+
+export default async function cast(opts: ICastOpts) {
+    const builder = await PlayerBuilder.autoInflate(opts.config);
     builder.addDevice(new ChromecastDevice(opts.device));
     const player = builder.build();
     await player.playUrl(opts.url);

--- a/src/cli/commands/cast.ts
+++ b/src/cli/commands/cast.ts
@@ -1,0 +1,9 @@
+import { ChromecastDevice } from "../../device";
+import { PlayerBuilder } from "../../player";
+
+export default async function cast(opts: {device: string, url: string}) {
+    const builder = await PlayerBuilder.autoInflate();
+    builder.addDevice(new ChromecastDevice(opts.device));
+    const player = builder.build();
+    await player.playUrl(opts.url);
+}

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -1,40 +1,30 @@
-// tslint:disable no-console
+import fs from "fs-extra";
+import pathlib from "path";
 
-import { consoleWrite, prompt } from "./util";
+export async function readConfig(path: string) {
+    const raw = await fs.readFile(path);
+    return JSON.parse(raw.toString());
+}
 
-import { ConfigExtractor, DEFAULT_CONFIG_PATH } from "../config";
+export async function writeConfig(path: string, obj: any) {
+    await fs.mkdirp(pathlib.dirname(path));
+    return fs.writeFile(path, JSON.stringify(obj, null, "  "));
+}
 
-export default async function configure() {
-    consoleWrite(`
-This process will attempt to extract configuration for as many Apps as
-possible from Chrome. You should close Chrome now for this to complete
-successfully.
-
-On macOS you will be prompted to enter a password so we can decrypt
-cookies for some apps.
-    `);
-
-    await prompt("\nPress enter to continue");
-
-    const extractor = new ConfigExtractor();
-    try {
-        const config = await extractor.extract();
-
-        consoleWrite(`Extracted config:`);
-        console.log(config);
-
-        await extractor.writeConfig(DEFAULT_CONFIG_PATH, config);
-        consoleWrite(`
-Wrote config to: ${DEFAULT_CONFIG_PATH}
-        `);
-
-    } catch (e) {
-        consoleWrite(`
-Unable to complete auto-config extraction:
-
-    ${e}
-
-You may need to quit Chrome before trying again.
-        `);
+export async function config(configPath: string, key: string, value?: string) {
+    const json = await readConfig(configPath);
+    if (value) {
+        json[key] = value;
+        await fs.writeFile(configPath, JSON.stringify(json, null, "  "));
+        return;
     }
+
+    // tslint:disable-next-line no-console
+    console.log(`${key}: `, json[key]);
+}
+
+export async function unconfig(configPath: string, key: string) {
+    const json = await readConfig(configPath);
+    delete json[key];
+    await fs.writeFile(configPath, JSON.stringify(json, null, "  "));
 }

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -1,0 +1,40 @@
+// tslint:disable no-console
+
+import { consoleWrite, prompt } from "./util";
+
+import { ConfigExtractor, DEFAULT_CONFIG_PATH } from "../config";
+
+export default async function configure() {
+    consoleWrite(`
+This process will attempt to extract configuration for as many Apps as
+possible from Chrome. You should close Chrome now for this to complete
+successfully.
+
+On macOS you will be prompted to enter a password so we can decrypt
+cookies for some apps.
+    `);
+
+    await prompt("\nPress enter to continue");
+
+    const extractor = new ConfigExtractor();
+    try {
+        const config = await extractor.extract();
+
+        consoleWrite(`Extracted config:`);
+        console.log(config);
+
+        await extractor.writeConfig(DEFAULT_CONFIG_PATH, config);
+        consoleWrite(`
+Wrote config to: ${DEFAULT_CONFIG_PATH}
+        `);
+
+    } catch (e) {
+        consoleWrite(`
+Unable to complete auto-config extraction:
+
+    ${e}
+
+You may need to quit Chrome before trying again.
+        `);
+    }
+}

--- a/src/cli/commands/util.ts
+++ b/src/cli/commands/util.ts
@@ -1,0 +1,20 @@
+// tslint:disable no-console
+
+import readline from "readline";
+
+export async function prompt(promptText: string) {
+    return new Promise(resolve => {
+        const prompter = readline.createInterface({
+            input: process.stdin,
+            output: process.stdout,
+        });
+        prompter.question(promptText, result => {
+            prompter.close();
+            resolve(result);
+        });
+    });
+}
+
+export function consoleWrite(str: string) {
+    console.log(str.trim());
+}

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -8,8 +8,8 @@ const debug = _debug("babbling:config");
 
 import { CookieExtractor, LocalStorageExtractor } from "chromagnon";
 import { IApp, IAppConstructor, IPlayerEnabledConstructor, Opts } from "../app";
-import { isConfigurable } from "./model";
 import { readConfig } from "./commands/config";
+import { isConfigurable } from "./model";
 
 export const DEFAULT_CONFIG_PATH = pathlib.join(
     os.homedir(),

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -1,0 +1,69 @@
+import fs from "fs-extra";
+import os from "os";
+import pathlib from "path";
+import util from "util";
+
+import _debug from "debug";
+const debug = _debug("babbling:config");
+
+import { CookieExtractor, LocalStorageExtractor } from "chromagnon";
+import { IApp, IAppConstructor } from "../app";
+import { isConfigurable } from "./model";
+
+export const DEFAULT_CONFIG_PATH = pathlib.join(
+    os.homedir(),
+    ".config/babbling/auto-config.json",
+);
+
+async function *getAppConstructors(): AsyncIterable<IAppConstructor<any, IApp>> {
+    const allExports = require("../index");
+    for (const name of Object.keys(allExports)) {
+        if (name.endsWith("App") && allExports[name] instanceof Function) {
+            yield allExports[name];
+        }
+    }
+}
+
+export class ConfigExtractor {
+    public async extract() {
+        const cookies = await CookieExtractor.create();
+        const storage = await LocalStorageExtractor.create();
+
+        const config: any = {};
+
+        try {
+            for await (const app of getAppConstructors()) {
+                if (isConfigurable(app)) {
+                    debug("Configuring", app.name);
+                    const extracted = await app.configurable.extractConfig(cookies, storage);
+                    config[app.name] = extracted;
+                }
+            }
+        } finally {
+            cookies.close();
+        }
+
+        return config;
+    }
+
+    public async writeConfig(path: string, config: any) {
+        await fs.mkdirp(pathlib.dirname(path));
+        return fs.writeFile(path, JSON.stringify(config, null, "  "));
+    }
+}
+
+export async function *importConfig(configPath?: string) {
+    const contents = await fs.readFile(configPath || DEFAULT_CONFIG_PATH);
+    const config = JSON.parse(contents.toString());
+
+    yield *importConfigFromJson(config);
+}
+
+export async function *importConfigFromJson(config: any) {
+
+    for await (const app of getAppConstructors()) {
+        if (config[app.name]) {
+            yield [app, config[app.name]];
+        }
+    }
+}

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -9,6 +9,7 @@ const debug = _debug("babbling:config");
 import { CookieExtractor, LocalStorageExtractor } from "chromagnon";
 import { IApp, IAppConstructor, IPlayerEnabledConstructor, Opts } from "../app";
 import { isConfigurable } from "./model";
+import { readConfig } from "./commands/config";
 
 export const DEFAULT_CONFIG_PATH = pathlib.join(
     os.homedir(),
@@ -45,16 +46,10 @@ export class ConfigExtractor {
 
         return config;
     }
-
-    public async writeConfig(path: string, config: any) {
-        await fs.mkdirp(pathlib.dirname(path));
-        return fs.writeFile(path, JSON.stringify(config, null, "  "));
-    }
 }
 
 export async function *importConfig(configPath?: string) {
-    const contents = await fs.readFile(configPath || DEFAULT_CONFIG_PATH);
-    const config = JSON.parse(contents.toString());
+    const config = await readConfig(configPath || DEFAULT_CONFIG_PATH);
 
     yield *importConfigFromJson(config);
 }

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -7,7 +7,7 @@ import _debug from "debug";
 const debug = _debug("babbling:config");
 
 import { CookieExtractor, LocalStorageExtractor } from "chromagnon";
-import { IApp, IAppConstructor } from "../app";
+import { IApp, IAppConstructor, IPlayerEnabledConstructor, Opts } from "../app";
 import { isConfigurable } from "./model";
 
 export const DEFAULT_CONFIG_PATH = pathlib.join(
@@ -59,11 +59,13 @@ export async function *importConfig(configPath?: string) {
     yield *importConfigFromJson(config);
 }
 
+type ConfigPair<TOpts extends Opts> = [IPlayerEnabledConstructor<TOpts, IApp>, Opts];
+
 export async function *importConfigFromJson(config: any) {
 
     for await (const app of getAppConstructors()) {
         if (config[app.name]) {
-            yield [app, config[app.name]];
+            yield [app, config[app.name]] as ConfigPair<any>;
         }
     }
 }

--- a/src/cli/configurables.ts
+++ b/src/cli/configurables.ts
@@ -14,7 +14,7 @@ async function cookieString(c: CookieExtractor, url: string) {
             str += "; ";
         }
 
-        str += `${cookie.name}: ${cookie.value}`;
+        str += `${cookie.name}=${cookie.value}`;
     }
 
     return str;

--- a/src/cli/configurables.ts
+++ b/src/cli/configurables.ts
@@ -1,0 +1,35 @@
+import { CookieExtractor, LocalStorageExtractor } from "chromagnon";
+
+import { IConfigurable } from "./model";
+
+export interface ICookieConfig {
+    cookies: string;
+}
+
+async function cookieString(c: CookieExtractor, url: string) {
+    let str = "";
+
+    for await (const cookie of c.query(url)) {
+        if (str.length) {
+            str += "; ";
+        }
+
+        str += `${cookie.name}: ${cookie.value}`;
+    }
+
+    return str;
+}
+
+export class CookiesConfigurable<T extends ICookieConfig> implements IConfigurable<T> {
+    constructor(private url: string) {}
+
+    public async extractConfig(
+        cookies: CookieExtractor,
+        storage: LocalStorageExtractor,
+    ): Promise<Partial<T> | undefined> {
+        const s = await cookieString(cookies, this.url);
+        if (s) {
+            return { cookies: s } as Partial<T>;
+        }
+    }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+// tslint:disable no-console
+
+import { main } from "./cli";
+
+main(process.argv).catch(e => console.error(e));

--- a/src/cli/model.ts
+++ b/src/cli/model.ts
@@ -1,0 +1,17 @@
+import { CookieExtractor, LocalStorageExtractor } from "chromagnon";
+import { IAppConstructor } from "../app";
+
+export interface IConfigurable<TConfig> {
+    extractConfig(
+        cookies: CookieExtractor,
+        storage: LocalStorageExtractor,
+    ): Promise<Partial<TConfig> | undefined>;
+}
+
+export interface IConfigurableApp<TConfig> extends IAppConstructor<any, any> {
+    configurable: IConfigurable<TConfig>;
+}
+
+export function isConfigurable<Opts extends []>(app: IAppConstructor<Opts, any>): app is IConfigurableApp<Opts> {
+    return (app as any).configurable;
+}

--- a/src/player.ts
+++ b/src/player.ts
@@ -2,11 +2,14 @@ import _debug from "debug";
 const debug = _debug("babbling:player");
 
 import { AppFor, IApp, IPlayableOptions, IPlayerEnabledConstructor, OptionsFor, Opts } from "./app";
+import { importConfig } from "./cli/config";
+import { IConfigurable, IConfigurableApp } from "./cli/model";
 import { ChromecastDevice } from "./device";
 
 interface IConfiguredApp<TConstructor extends IPlayerEnabledConstructor<Opts, IApp>> {
     appConstructor: TConstructor;
     options: OptionsFor<TConstructor>;
+    autoConfigure?: boolean;
 }
 
 function pickAppForUrl(
@@ -69,20 +72,39 @@ class Player {
     }
 }
 
+type IPlayerEnabled = IPlayerEnabledConstructor<Opts, IApp>;
+type IPlayerConfigurable = IPlayerEnabledConstructor<Opts, IApp> & IConfigurableApp<Opts>;
+
 export class PlayerBuilder {
+    public static async autoInflate() {
+        const builder = new PlayerBuilder();
+        for await (const [app, opts ] of importConfig()) {
+            builder.withApp(app, ... opts);
+        }
+
+        return builder;
+    }
 
     private apps: Array<IConfiguredApp<any>> = [];
     private devices: ChromecastDevice[] = [];
     private opts: IPlayerOpts = {};
 
-    public withApp<TConstructor extends IPlayerEnabledConstructor<Opts, IApp>>(
+    public withApp<TConstructor extends IPlayerEnabled>(
         appConstructor: TConstructor,
         ...options: OptionsFor<TConstructor>  // tslint:disable-line
     ) {
-        this.apps.push({
-            appConstructor,
-            options,
-        });
+        const index = this.apps.findIndex(old => old.appConstructor === appConstructor);
+        if (index !== -1) {
+            // extend existing config, for use with autoInflate();
+            this.apps[index].options = this.apps[index].options.map((old, i) => {
+                return Object.assign(old, options[i]);
+            });
+        } else {
+            this.apps.push({
+                appConstructor,
+                options,
+            });
+        }
         return this;
     }
 

--- a/src/player.ts
+++ b/src/player.ts
@@ -76,10 +76,10 @@ type IPlayerEnabled = IPlayerEnabledConstructor<Opts, IApp>;
 type IPlayerConfigurable = IPlayerEnabledConstructor<Opts, IApp> & IConfigurableApp<Opts>;
 
 export class PlayerBuilder {
-    public static async autoInflate() {
+    public static async autoInflate(configPath?: string) {
         const builder = new PlayerBuilder();
 
-        for await (const [app, opts] of importConfig()) {
+        for await (const [app, opts] of importConfig(configPath)) {
             builder.withApp(app, opts);
         }
 

--- a/src/player.ts
+++ b/src/player.ts
@@ -78,8 +78,9 @@ type IPlayerConfigurable = IPlayerEnabledConstructor<Opts, IApp> & IConfigurable
 export class PlayerBuilder {
     public static async autoInflate() {
         const builder = new PlayerBuilder();
-        for await (const [app, opts ] of importConfig()) {
-            builder.withApp(app, ... opts);
+
+        for await (const [app, opts] of importConfig()) {
+            builder.withApp(app, opts);
         }
 
         return builder;


### PR DESCRIPTION
Includes a CLI that can be installed globally supporting:

```
babbling auto-auth  
babbling cast <url>
```

- `auto-auth` Reads cookies and tokens from Chrome into a config file to enable easier PlayerBuilder instantiation, and also enables the `babbling cast` command

In addition, so you don't have to specify the device every time you can use:

```
babbling config device "My Chromecast"
```

for example, to always cast to a device called "My Chromecast."

Once `auto-auth` is complete, you can acquire a `PlayerBuilder` with all apps authenticated using:

```typescript
const builder = await PlayerBuilder.autoInflate()

// we don't yet use the `device` config, so add it:
builder.addDevice(new ChromecastDevice("My Chromecast"));

// add extra config if desired (it gets merged)
builder.withApp(YoutubeApp, { deviceName: "Smart Home" });

// done!
builder.build();
```

Babbling will handle the file reading and app auth for you!