### PR TITLE
Support Queues for Babbler-based Apps

### DIFF
--- a/src/apps/babbler/daemon.ts
+++ b/src/apps/babbler/daemon.ts
@@ -9,7 +9,7 @@ import { BabblerBaseApp } from "./base";
 
 const DAEMON_ENV = "IS_BABBLER_DAEMON";
 
-export type RPCMethod = "loadUrl";
+export type RPCMethod = "loadMedia";
 export type RPC = [ RPCMethod, any[] ]; // TODO type safety on args?
 
 export interface IDaemonOptions {

--- a/src/apps/babbler/model.ts
+++ b/src/apps/babbler/model.ts
@@ -1,0 +1,9 @@
+
+// tslint:disable no-bitwise
+export enum SenderCapabilities {
+    None = 0,
+
+    QueueNext = 1 << 1,
+    QueuePrev = 1 << 2,
+}
+// tslint:enable no-bitwise

--- a/src/apps/babbler/model.ts
+++ b/src/apps/babbler/model.ts
@@ -3,7 +3,9 @@
 export enum SenderCapabilities {
     None = 0,
 
-    QueueNext = 1 << 1,
-    QueuePrev = 1 << 2,
+    DeferredInfo = 1 << 1,
+
+    QueueNext = 1 << 2,
+    QueuePrev = 1 << 3,
 }
 // tslint:enable no-bitwise

--- a/src/apps/prime.ts
+++ b/src/apps/prime.ts
@@ -6,7 +6,7 @@ import { IDevice } from "nodecastor";
 
 import { IPlayableOptions, IQueryResult } from "../app";
 import { CookiesConfigurable } from "../cli/configurables";
-import { BabblerBaseApp } from "./babbler/base";
+import { BabblerBaseApp, IPlayableInfo, IQueueItem } from "./babbler/base";
 import { SenderCapabilities } from "./babbler/model";
 
 export interface IPrimeOpts {
@@ -23,6 +23,36 @@ function shuffle(a: any[]) {
         a[j] = x;
     }
 }
+
+function toQueueItem(item: IBaseObj): IQueueItem<IBaseObj> {
+    let title = item.title;
+    let images: string[] | undefined;
+
+    if (item.cover) {
+        images = [item.cover];
+    }
+
+    const episode = item as IEpisode;
+    if (episode.series) {
+        title = `${episode.series.title} - ${title}`;
+
+        if (!images && episode.series.cover) {
+            images = [episode.series.cover];
+        }
+    }
+
+    return {
+        id: item.id,
+        media: item,
+        metadata: {
+            images,
+            title,
+        },
+    };
+}
+
+/** Number of items to return for QUEUE requests */
+const QUEUE_SIZE = 5;
 
 /**
  * Amazon Prime Video
@@ -103,8 +133,8 @@ export class PrimeApp extends BabblerBaseApp {
             appId: opts.appId,
 
             // tslint:disable no-bitwise
-            capabilities: SenderCapabilities.QueueNext
-                | SenderCapabilities.QueuePrev,
+            capabilities: SenderCapabilities.DeferredInfo
+                | SenderCapabilities.QueueNext,
             // tslint:enable no-bitwise
 
             daemonOptions: opts,
@@ -154,30 +184,6 @@ export class PrimeApp extends BabblerBaseApp {
             throw new Error(`${id} is a season`);
         }
 
-        const {
-            manifests,
-            licenseUrl,
-        } = await this.api.getPlaybackInfo(info.id);
-
-        // pick *some* manifest
-        shuffle(manifests);
-
-        let title = info.title;
-        let images: string[] | undefined;
-
-        if (info.cover) {
-            images = [info.cover];
-        }
-
-        const episode = info as IEpisode;
-        if (episode.series) {
-            title = `${episode.series.title} - ${title}`;
-
-            if (!images && episode.series.cover) {
-                images = [episode.series.cover];
-            }
-        }
-
         let startTime = opts.startTime;
         if (startTime === undefined) {
             try {
@@ -188,21 +194,10 @@ export class PrimeApp extends BabblerBaseApp {
             }
         }
 
-        const chosenUrl =  manifests[0].url;
-        debug(
-            "got playback info; loading manifest @",
-            chosenUrl,
-            "; starting at", startTime,
-        );
-        return this.loadUrl(chosenUrl, {
-            licenseUrl,
-            media: info,
-            metadata: {
-                images,
-                title,
-            },
-            startTime,
-        });
+        debug("load", info, "at", startTime);
+        return this.loadMedia(Object.assign({
+            currentTime: startTime,
+        }, toQueueItem(info)));
     }
 
     protected async performLicenseRequest(
@@ -213,13 +208,71 @@ export class PrimeApp extends BabblerBaseApp {
         return this.api.fetchLicense(url, buffer);
     }
 
-    protected async performQueueRequest(
-        mode: string,
+    protected async loadInfoFor(
         contentId: string,
-    ) {
-        debug("TODO: queue", mode, contentId);
-        // TODO
-        return [];
+    ): Promise<IPlayableInfo> {
+        debug(`load playableInfo for ${contentId}`);
+
+        const {
+            manifests,
+            licenseUrl,
+        } = await this.api.getPlaybackInfo(contentId);
+
+        // pick *some* manifest
+        shuffle(manifests);
+
+        const chosenUrl = manifests[0].url;
+        debug(
+            `got playback info for ${contentId}; loading manifest @`,
+            chosenUrl,
+        );
+
+        return {
+            contentId,
+            contentUrl: chosenUrl,
+            customData: {
+                license: {
+                    ipc: true,
+                    url: licenseUrl,
+                },
+            },
+        };
+    }
+
+    protected async loadQueueAfter(
+        contentId: string,
+        media?: IBaseObj,
+    ): Promise<Array<IQueueItem<IBaseObj>>> {
+        // TODO we could fetch it, since we have the contentId
+        if (!media) return [];
+
+        if (media.type !== ContentType.EPISODE) {
+            debug(`cannot load queue for ${media.type} media`);
+            return [];
+        }
+
+        const episode = media as IEpisode;
+        if (!episode.series) {
+            // TODO we could fetch it...?
+            debug(`series for ${contentId} unknown`);
+            return [];
+        }
+
+        debug("queue after", contentId, media);
+
+        const episodes = await this.api.getEpisodes(episode.series.id);
+        const index = episodes.findIndex(ep => ep.id === contentId);
+        if (index === -1) {
+            debug(`couldn't find ${contentId} in episodes of ${episode.series.id}`);
+            return [];
+        }
+
+        const upNext = episodes.slice(
+            index + 1,
+            Math.min(index + 1 + QUEUE_SIZE, episodes.length - 1),
+        );
+
+        return upNext.map(toQueueItem);
     }
 
     protected async onPlayerPaused(

--- a/src/apps/prime.ts
+++ b/src/apps/prime.ts
@@ -7,6 +7,7 @@ import { IDevice } from "nodecastor";
 import { IPlayableOptions, IQueryResult } from "../app";
 import { CookiesConfigurable } from "../cli/configurables";
 import { BabblerBaseApp } from "./babbler/base";
+import { SenderCapabilities } from "./babbler/model";
 
 export interface IPrimeOpts {
     appId: string;
@@ -100,6 +101,12 @@ export class PrimeApp extends BabblerBaseApp {
     ) {
         super(device, {
             appId: opts.appId,
+
+            // tslint:disable no-bitwise
+            capabilities: SenderCapabilities.QueueNext
+                | SenderCapabilities.QueuePrev,
+            // tslint:enable no-bitwise
+
             daemonOptions: opts,
             useLicenseIpc: true,
         });
@@ -204,6 +211,15 @@ export class PrimeApp extends BabblerBaseApp {
     ): Promise<Buffer> {
         if (!url) throw new Error("No license url provided");
         return this.api.fetchLicense(url, buffer);
+    }
+
+    protected async performQueueRequest(
+        mode: string,
+        contentId: string,
+    ) {
+        debug("TODO: queue", mode, contentId);
+        // TODO
+        return [];
     }
 
     protected async onPlayerPaused(

--- a/src/device.ts
+++ b/src/device.ts
@@ -51,7 +51,7 @@ export class ChromecastDevice {
 
         return new Promise((resolve, reject) => {
             let options;
-            if (debug.enabled) {
+            if (_debug.enabled("chromecast")) {
                 options = {
                     logger: console,
                 };


### PR DESCRIPTION
To reiterate the changes described in 210d0a6:

> We now prefer sending only IQueueItems from the load method, renamed
to `loadMedia` instead of `loadUrl`, and fetch playback info
asynchronously via a new RPC method. This allows us to more easily
enqueue "next" items, since we don't have to include playback info
(IE: manifest URL and license URL) as part of the queue item—at least
for Prime, these are both separate requests that may not even be
necessary, since Chromecast loads the queue eagerly.
>
> By moving the playback info query to a separate step, we can have a
faster and more symmetrical API when using Queues. Of course, the
old way still works (with a slightly changed API) if you don't want
or need to support Queues.