### PR TITLE
Add media control APIs and CLI interface

### DIFF
--- a/src/@types/nodecastor.d.ts
+++ b/src/@types/nodecastor.d.ts
@@ -68,6 +68,7 @@ declare module "nodecastor" {
         channel: ICastChannel;
 
         application(id: string, callback: Callback<ICastApp>): void;
+        status(callback: Callback<IReceiverStatusMessage>): void;
         stop(): void;
         on(event: "connect", handler: () => any): IDevice;
         on(event: "status", handler: (status: IReceiverStatusMessage) => any): IDevice;

--- a/src/@types/nodecastor.d.ts
+++ b/src/@types/nodecastor.d.ts
@@ -21,6 +21,10 @@ declare module "nodecastor" {
         send(message: any): void;
     }
 
+    export interface ICastChannel {
+        send(message: any): void;
+    }
+
     export interface IAppStatus {
         appId: string;
         displayName: string;
@@ -60,6 +64,8 @@ declare module "nodecastor" {
 
     export interface IDevice {
         friendlyName: string;
+
+        channel: ICastChannel;
 
         application(id: string, callback: Callback<ICastApp>): void;
         stop(): void;

--- a/src/apps/util.ts
+++ b/src/apps/util.ts
@@ -1,4 +1,4 @@
-import { ICastSession } from "../cast";
+import { Callback, ICastSession, IDevice } from "../cast";
 
 export const awaitMessageOfType = (
     session: ICastSession, type: string,
@@ -20,3 +20,33 @@ export const awaitMessageOfType = (
 
     session.on("message", onMessage);
 });
+
+type Method0<TSelf, T> = (this: TSelf, callback: Callback<T>) => void;
+type Method1<TSelf, T, TArg> = (this: TSelf, arg: TArg, callback: Callback<T>) => void;
+type Method<TSelf, T> = Method0<TSelf, T> | Method1<TSelf, T, any>;
+
+type ArgsOf<TM> = TM extends Method0<infer _, infer T> ? void[] :
+    TM extends Method1<infer __, infer T2, infer TArg> ? [TArg] :
+    never;
+
+type ResultOf<TM> = TM extends Method0<infer _, infer T> ? T :
+    TM extends Method1<infer __, infer T2, infer TArg> ? T2 :
+    never;
+
+export function promise<TSelf, TM extends Method<TSelf, any>>(
+    device: TSelf,
+    method: TM,
+    ... args: ArgsOf<TM>
+): Promise<ResultOf<TM>> {
+    return new Promise<ResultOf<TM>>((resolve, reject) => {
+        const call = [...args, (err: Error | null, result: ResultOf<TM>) => {
+            if (err) reject(err);
+            else resolve(result);
+        }];
+        (method as any).apply(device, call);
+    });
+}
+
+export function getApp(device: IDevice, appId: string) {
+    return promise(device, device.application, appId);
+}

--- a/src/cast.ts
+++ b/src/cast.ts
@@ -19,6 +19,7 @@ export interface IDevice {
     friendlyName: string;
 
     application(id: string, callback: Callback<ICastApp>): void;
+    status(callback: Callback<IReceiverStatusMessage>): void;
     stop(): void;
     on(event: "connect", handler: () => any): IDevice;
     on(event: "status", handler: (status: IReceiverStatusMessage) => any): IDevice;

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -5,6 +5,7 @@ import yargs from "yargs";
 import { withConfig, withDevice, withKey, withValue } from "./args";
 import cast from "./commands/cast";
 import { config, unconfig } from "./commands/config";
+import mediaControlCommand from "./commands/do";
 import findByTitle from "./commands/find";
 import scanForDevices from "./commands/scan";
 import searchByTitle from "./commands/search";
@@ -35,6 +36,31 @@ parser.command(
             type: "string",
         }).demand("url");
     }, cast,
+);
+
+parser.command(
+    "do <cmd> [arg]", `Send a media control command`, args => {
+        return withDevice(withConfig(args)).positional("cmd", {
+            choices: [
+                "next", "prev",
+
+                "pause", "play", "play-again",
+                "skip-ad",
+                "stop",
+
+                "ff", "rew",
+
+                "mute", "unmute", "volume",
+            ],
+            describe: "The command to send",
+            type: "string",
+        })
+        .positional("arg", {
+            describe: "The numeric argument to the command (if any)",
+            type: "number",
+        })
+        .demand("cmd");
+    }, mediaControlCommand,
 );
 
 parser.command(

--- a/src/cli/commands/do.ts
+++ b/src/cli/commands/do.ts
@@ -1,0 +1,44 @@
+import { ChromecastDevice } from "../../device";
+
+export interface IMediaControlCommand {
+    cmd: string;
+    device: string;
+    arg?: number;
+}
+
+function requireArg(opts: IMediaControlCommand) {
+    if (opts.arg === undefined) {
+        throw new Error("You must provide [arg]");
+    }
+    return opts.arg;
+}
+
+export default async function mediaControlCommand(
+    opts: IMediaControlCommand,
+) {
+    const device = new ChromecastDevice(opts.device);
+    const controls = await device.openControls();
+
+    switch (opts.cmd) {
+    case "pause": controls.pause(); break;
+    case "play": controls.play(); break;
+    case "play-again": controls.playAgain(); break;
+    case "skip-ad": controls.skipAd(); break;
+    case "stop": controls.stop(); break;
+
+    case "next": controls.nextQueueItem(); break;
+    case "prev": controls.prevQueueItem(); break;
+
+    case "ff": controls.seekRelative(requireArg(opts)); break;
+    case "rew": controls.seekRelative(requireArg(opts)); break;
+    case "seek": controls.seekTo(requireArg(opts)); break;
+
+    case "mute": controls.setMuted(true); break;
+    case "unmute": controls.setMuted(false); break;
+
+    case "volume": controls.setVolume(requireArg(opts) / 10); break;
+
+    default:
+        throw new Error(`Unknown command '${opts.cmd}'`);
+    }
+}

--- a/src/cli/commands/do.ts
+++ b/src/cli/commands/do.ts
@@ -17,28 +17,34 @@ export default async function mediaControlCommand(
     opts: IMediaControlCommand,
 ) {
     const device = new ChromecastDevice(opts.device);
-    const controls = await device.openControls();
 
-    switch (opts.cmd) {
-    case "pause": controls.pause(); break;
-    case "play": controls.play(); break;
-    case "play-again": controls.playAgain(); break;
-    case "skip-ad": controls.skipAd(); break;
-    case "stop": controls.stop(); break;
+    try {
+        const controls = await device.openControls();
 
-    case "next": controls.nextQueueItem(); break;
-    case "prev": controls.prevQueueItem(); break;
+        switch (opts.cmd) {
+        case "pause": controls.pause(); break;
+        case "play": controls.play(); break;
+        case "play-again": controls.playAgain(); break;
+        case "skip-ad": controls.skipAd(); break;
+        case "stop": controls.stop(); break;
 
-    case "ff": controls.seekRelative(requireArg(opts)); break;
-    case "rew": controls.seekRelative(requireArg(opts)); break;
-    case "seek": controls.seekTo(requireArg(opts)); break;
+        case "next": controls.nextQueueItem(); break;
+        case "prev": controls.prevQueueItem(); break;
 
-    case "mute": controls.setMuted(true); break;
-    case "unmute": controls.setMuted(false); break;
+        case "ff": controls.seekRelative(requireArg(opts)); break;
+        case "rew": controls.seekRelative(requireArg(opts)); break;
+        case "seek": controls.seekTo(requireArg(opts)); break;
 
-    case "volume": controls.setVolume(requireArg(opts) / 10); break;
+        case "mute": controls.setMuted(true); break;
+        case "unmute": controls.setMuted(false); break;
 
-    default:
-        throw new Error(`Unknown command '${opts.cmd}'`);
+        case "volume": controls.setVolume(requireArg(opts) / 10); break;
+
+        default:
+            throw new Error(`Unknown command '${opts.cmd}'`);
+        }
+
+    } finally {
+        device.close();
     }
 }

--- a/src/controls.ts
+++ b/src/controls.ts
@@ -1,9 +1,41 @@
-import { IDevice } from "nodecastor";
+import _debug from "debug";
+const debug = _debug("babbling:controls");
+
 import { MEDIA_NS } from "./apps/base";
+import { awaitMessageOfType, promise } from "./apps/util";
+import { ICastSession, IDevice } from "./cast";
 
 export class MediaControls {
+    public static async open(device: IDevice) {
+        const status = await promise(device, device.status);
+
+        if (!status.applications || !status.applications.length) {
+            throw new Error("No running application");
+        }
+
+        try {
+            const app = await promise(device, device.application, status.applications[0].appId);
+            const session = await promise(app, app.join, MEDIA_NS);
+
+            // request media status so we can get the mediaSession
+            session.send({ type: "GET_STATUS" });
+
+            const mediaStatus = await awaitMessageOfType(session, "MEDIA_STATUS");
+            debug("GOT media status", mediaStatus);
+
+            return new MediaControls(session, mediaStatus.status[0].mediaSessionId);
+        } catch (e) {
+            if (e.message && e.message.includes("namespace")) {
+                throw new Error("No media app running");
+            }
+
+            throw e;
+        }
+    }
+
     constructor(
-        private device: IDevice,
+        private session: ICastSession,
+        private mediaSessionId: number,
     ) {}
 
     public pause() { this.sendSimple("PAUSE"); }
@@ -57,9 +89,10 @@ export class MediaControls {
     }
 
     private sendData(data: any) {
-        this.device.channel.send({
-            data,
-            namespace: MEDIA_NS,
-        });
+        const filled = Object.assign({
+            mediaSessionId: this.mediaSessionId,
+        }, data);
+        debug("SEND", filled);
+        this.session.send(filled);
     }
 }

--- a/src/controls.ts
+++ b/src/controls.ts
@@ -1,0 +1,65 @@
+import { IDevice } from "nodecastor";
+import { MEDIA_NS } from "./apps/base";
+
+export class MediaControls {
+    constructor(
+        private device: IDevice,
+    ) {}
+
+    public pause() { this.sendSimple("PAUSE"); }
+    public play() { this.sendSimple("PLAY"); }
+    public stop() { this.sendSimple("STOP"); }
+
+    public playAgain() { this.sendSimple("PLAY_AGAIN"); }
+    public skipAd() { this.sendSimple("SKIP_AD"); }
+
+    public nextQueueItem() { this.sendSimple("QUEUE_NEXT"); }
+    public prevQueueItem() { this.sendSimple("QUEUE_PREV"); }
+
+    public seekRelative(relativeSeconds: number) {
+        this.sendData({
+            relativeTime: relativeSeconds,
+            type: "SEEK",
+        });
+    }
+    public seekTo(videoTimestampSeconds: number) {
+        this.sendData({
+            currentTime: videoTimestampSeconds,
+            type: "SEEK",
+        });
+    }
+
+    public setMuted(isMuted: boolean) {
+        this.sendData({
+            type: "SET_VOLUME",
+            volume: {
+                muted: isMuted,
+            },
+        });
+    }
+
+    /**
+     * @param level In range [0, 1]
+     */
+    public setVolume(level: number) {
+        this.sendData({
+            type: "SET_VOLUME",
+            volume: {
+                level,
+            },
+        });
+    }
+
+    private sendSimple(type: string) {
+        this.sendData({
+            type,
+        });
+    }
+
+    private sendData(data: any) {
+        this.device.channel.send({
+            data,
+            namespace: MEDIA_NS,
+        });
+    }
+}

--- a/src/device.ts
+++ b/src/device.ts
@@ -39,7 +39,7 @@ export class ChromecastDevice {
 
     public async openControls() {
         const device = await this.getCastorDevice();
-        return new MediaControls(device);
+        return MediaControls.open(device);
     }
 
     /**

--- a/src/device.ts
+++ b/src/device.ts
@@ -4,6 +4,7 @@ import _debug from "debug";
 const debug = _debug("babbling:device");
 
 import { AppFor, IApp, IAppConstructor, OptionsFor, Opts } from "./app";
+import { MediaControls } from "./controls";
 import { findFirst } from "./scan";
 
 export class ChromecastDevice {
@@ -34,6 +35,11 @@ export class ChromecastDevice {
         debug("Starting", appConstructor.name);
         await app.start();
         return app;
+    }
+
+    public async openControls() {
+        const device = await this.getCastorDevice();
+        return new MediaControls(device);
     }
 
     /**

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -1,9 +1,7 @@
 import _debug from "debug";
 const debug = _debug("babbling:scan");
 
-import nodecastor from "nodecastor";
-
-import { IDevice } from "./cast";
+import nodecastor, { IDevice } from "nodecastor";
 
 export enum ScanAction {
     StopScanning,


### PR DESCRIPTION
Includes a new utility for directly calling callback-based methods and getting back a promise, instead of doing our weird `util.promisify`-`.bind()` dance.