### PR TITLE
Add support for "real" Prime video casting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -117,8 +117,7 @@
     "@types/node": {
       "version": "12.0.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.10.tgz",
-      "integrity": "sha512-LcsGbPomWsad6wmMNv7nBLw7YYYyfdYcz6xryKYQhx89c3XXan+8Q6AJ43G5XDIaklaVkK3mE4fCb0SBvMiPSQ==",
-      "dev": true
+      "integrity": "sha512-LcsGbPomWsad6wmMNv7nBLw7YYYyfdYcz6xryKYQhx89c3XXan+8Q6AJ43G5XDIaklaVkK3mE4fCb0SBvMiPSQ=="
     },
     "@types/request": {
       "version": "2.48.1",
@@ -146,6 +145,14 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.5.tgz",
       "integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg==",
       "dev": true
+    },
+    "@types/uuid": {
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.5.tgz",
+      "integrity": "sha512-MNL15wC3EKyw1VLF+RoVO4hJJdk9t/Hlv3rt1OL65Qvuadm4BYo6g9ZJQqoq7X8NBFSsQXgAujWciovh2lpVjA==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/yargs": {
       "version": "13.0.0",
@@ -1398,9 +1405,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.includes": {
       "version": "4.3.0",
@@ -2028,9 +2035,9 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
         }
       }
     },
@@ -2393,9 +2400,9 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
     },
     "verror": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "nodecastor": "github:dhleong/nodecastor#e18189c",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.7",
+    "uuid": "^3.3.3",
     "yargs": "^13.3.0",
     "youtubish": "^1.1.0"
   },
@@ -53,6 +54,7 @@
     "@types/mocha": "^5.2.7",
     "@types/node": "^12.0.10",
     "@types/request-promise-native": "^1.0.16",
+    "@types/uuid": "^3.4.5",
     "@types/yargs": "^13.0.0",
     "chai": "^4.2.0",
     "mocha": "^6.1.4",

--- a/src/apps/prime/api.ts
+++ b/src/apps/prime/api.ts
@@ -1,0 +1,245 @@
+import _debug from "debug";
+const debug = _debug("babbling:PrimeApp:api");
+
+import crypto from "crypto";
+import os from "os";
+import { gzip } from "zlib";
+
+import request from "request-promise-native";
+import generateRandomUUID from "uuid/v4";
+
+import { generateDeviceId } from "chakram-ts/dist/util";
+import { IPrimeApiOpts } from "./config";
+
+// ======= constants ======================================
+
+const DEFAULT_API_DOMAIN = "api.amazon.com";
+
+const ID_NAMESPACE = "com.github.babbler.prime";
+
+const APP_NAME = "com.amazon.avod.thirdpartyclient";
+const APP_VERSION = "253188041";
+const DEVICE_MODEL = "android";
+const DEVICE_TYPE = "A43PXU4ZN2AL1";
+const OS_VERSION = "25";
+const SOFTWARE_VERSION = "2";
+
+// ======= public interface ===============================
+
+export class PrimeApi {
+    public readonly deviceId: string;
+
+    private readonly opts: IPrimeApiOpts;
+    private readonly language = "en-US";
+    private readonly deviceNameBase = "User\u2019s Babbling";
+
+    constructor(options: IPrimeApiOpts = {}) {
+        this.opts = options;
+        this.deviceId = options.deviceId || generateDeviceId(
+            ID_NAMESPACE,
+            os.hostname(),
+        ).substring(0, 32);
+    }
+
+    public async login(email: string, password: string) {
+        const body: any = {
+            auth_data: {
+                use_global_authentication: "true",
+                user_id_password: {
+                    password,
+                    user_id: email,
+                },
+            },
+            cookies: {
+                domain: ".amazon.com",
+                website_cookies: [],
+            },
+            requested_extensions: [
+                "device_info",
+                "customer_info",
+            ],
+            requested_token_type: ["bearer", "mac_dms", "website_cookies"],
+        };
+
+        const registrationData = this.generateDeviceData();
+        registrationData.device_name = `${this.deviceNameBase}%DUPE_STRATEGY_2ND%`;
+        body.registration_data = registrationData;
+
+        const frc = await this.generateFrcCookies();
+        if (frc !== null) {
+            debug(`generated cookies: ${frc}`);
+            body.user_context_map = {
+                frc,
+            };
+        }
+
+        const response = await request.post({
+            body,
+            headers: this.generateHeaders(),
+            json: true,
+            url: this.buildUrl("/auth/register"),
+        });
+
+        const { success } = response.response;
+        if (!success) throw new Error(`Login unsuccessful: ${response}`);
+        if (!(success && success.tokens)) {
+            throw new Error("Logged in successfully but didn't get tokens");
+        }
+
+        debug("login successful = ", success);
+        return {
+            refreshToken: success.tokens.bearer.refresh_token,
+        };
+    }
+
+    public async generatePreAuthorizedLinkCode(refreshToken: string) {
+        debug(`generating pre-authorized link code...`);
+        const body = {
+            auth_data: {
+                access_token: refreshToken,
+            },
+            code_data: this.generateDeviceData(),
+        };
+
+        const response = await request.post({
+            body,
+            headers: this.generateHeaders(),
+            json: true,
+            url: this.buildUrl("/auth/create/code"),
+        });
+
+        if (!response.code) {
+            throw new Error(JSON.stringify(response));
+        }
+
+        // should we cache for response.expires_in seconds?
+        debug(`generated pre-authorized link code: ${response.code}`);
+        return response.code;
+    }
+
+    public getLanguage() {
+        return this.language;
+    }
+
+    public async generateFrcCookies() {
+        const cookies = JSON.stringify({
+            ApplicationName: APP_NAME,
+            ApplicationVersion: APP_VERSION,
+            DeviceLanguage: this.language,
+            DeviceName: "walleye/google/Pixel 2",
+            DeviceOSVersion: "google/walleye/walleye:8.1.0/OPM1.171019.021/4565141:user/release-keys",
+            IpAddress: getIpAddress(),
+            ScreenHeightPixels: "1920",
+            ScreenWidthPixels: "1280",
+            TimeZone: "-04:00",
+        });
+
+        debug("generating FRC cookies from: ", cookies);
+
+        // gzip
+        const zipped: Buffer = await new Promise((resolve, reject) => {
+            gzip(cookies, {}, (e, result) => {
+                if (e) reject(e);
+                else resolve(result);
+            });
+        });
+
+        // Cipher instance = Cipher.getInstance("AES/CBC/PKCS5Padding");
+        // instance.init(1, b(str2, "AES/CBC/PKCS7Padding"));
+        const key = this.createSaltedKey("AES/CBC/PKCS7Padding");
+        const iv = crypto.randomBytes(16);
+        const cipher = crypto.createCipheriv("aes-128-cbc", key, iv);
+
+        // toByteArray = instance.doFinal(toByteArray);
+        // byte[] iv = instance.getIV();
+        const cipheredBase = cipher.update(zipped);
+        const ciphered = Buffer.concat([cipheredBase, cipher.final()]);
+
+        // Mac instance2 = Mac.getInstance("HmacSHA256");
+        // instance2.init(b(str2, "HmacSHA256"));
+        // instance2.update(iv);
+        // instance2.update(toByteArray);
+        // byte[] doFinal = instance2.doFinal();
+        const hmac = crypto.createHmac("sha256", this.createSaltedKey("HmacSHA256"));
+        hmac.update(iv);
+        hmac.update(ciphered);
+        const hmacd = hmac.digest();
+
+        // byte[] bArr = new byte[(toByteArray.length + 25)];
+        // bArr[0] = (byte) 0;
+        // System.arraycopy(doFinal, 0, bArr, 1, 8);
+        // System.arraycopy(iv, 0, bArr, 9, 16);
+        // System.arraycopy(toByteArray, 0, bArr, 25, toByteArray.length);
+        const toBase64Encode = Buffer.concat([
+            Buffer.of(0),
+            hmacd.slice(0, 8),
+            iv,
+            ciphered,
+        ]);
+
+        // return Base64.encodeToString(bArr, 2);
+        return toBase64Encode.toString("base64");
+    }
+
+    private buildUrl(path: string): string {
+        const domain = this.apiDomain();
+        return `https://${domain}/${path}`;
+    }
+
+    private apiDomain(): string {
+        return this.opts.apiDomain || DEFAULT_API_DOMAIN;
+    }
+
+    private createSaltedKey(salt: crypto.BinaryLike) {
+        // return new SecretKeySpec(
+        //      SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1")
+        //          .generateSecret(
+        //              new PBEKeySpec(
+        //                  str.toCharArray(), str2.getBytes("UTF-8"), 1000, 128
+        //              )
+        //          ).getEncoded(),
+        //          "AES"
+        //      );
+        return crypto.pbkdf2Sync(
+            this.deviceId,
+            salt,
+            1000, // iterations
+            16, // key length (in bytes, vs Java's bits)
+            "SHA1", // hash
+        );
+    }
+
+    private generateDeviceData(): any {
+        return {
+            domain: "Device",
+
+            app_name: APP_NAME,
+            app_version: APP_VERSION,
+            device_model: DEVICE_MODEL,
+            device_serial: this.deviceId,
+            device_type: DEVICE_TYPE,
+            os_version: OS_VERSION,
+            software_version: SOFTWARE_VERSION,
+        };
+    }
+
+    private generateHeaders() {
+        return {
+            "Accept-Charset": "utf-8",
+            "x-amzn-identity-auth-domain": this.apiDomain(),
+            "x-amzn-requestid": generateRandomUUID(),
+        };
+    }
+
+}
+
+function getIpAddress() {
+    const ifaces = os.networkInterfaces();
+    for (const ifaceName of Object.keys(ifaces)) {
+        for (const iface of ifaces[ifaceName]) {
+            if (!iface.internal && iface.family === "IPv4") {
+                return iface.address;
+            }
+        }
+    }
+}

--- a/src/apps/prime/api.ts
+++ b/src/apps/prime/api.ts
@@ -24,6 +24,72 @@ const DEVICE_TYPE = "A43PXU4ZN2AL1";
 const OS_VERSION = "25";
 const SOFTWARE_VERSION = "2";
 
+// ======= utils ==========================================
+
+export async function generateFrcCookies(
+    deviceId: string,
+    language: string,
+) {
+    const cookies = JSON.stringify({
+        ApplicationName: APP_NAME,
+        ApplicationVersion: APP_VERSION,
+        DeviceLanguage: language,
+        DeviceName: "walleye/google/Pixel 2",
+        DeviceOSVersion: "google/walleye/walleye:8.1.0/OPM1.171019.021/4565141:user/release-keys",
+        IpAddress: getIpAddress(),
+        ScreenHeightPixels: "1920",
+        ScreenWidthPixels: "1280",
+        TimeZone: "-04:00",
+    });
+
+    debug("generating FRC cookies from: ", cookies);
+
+    // gzip
+    const zipped: Buffer = await new Promise((resolve, reject) => {
+        gzip(cookies, {}, (e, result) => {
+            if (e) reject(e);
+            else resolve(result);
+        });
+    });
+
+    // encrypt the cookies JSON
+    // don't ask about the salts used for the keys; I don't make the rules ;)
+    const key = createSaltedKey(deviceId, "AES/CBC/PKCS7Padding");
+    const iv = crypto.randomBytes(16);
+    const cipher = crypto.createCipheriv("aes-128-cbc", key, iv);
+    const cipheredBase = cipher.update(zipped);
+    const ciphered = Buffer.concat([cipheredBase, cipher.final()]);
+
+    // create an hmac digest containing the IV and the ciphered data
+    const hmac = crypto.createHmac(
+        "sha256",
+        createSaltedKey(deviceId, "HmacSHA256"),
+    );
+    hmac.update(iv);
+    hmac.update(ciphered);
+    const hmacd = hmac.digest();
+
+    // build the cookies buffer
+    const toBase64Encode = Buffer.concat([
+        Buffer.of(0),
+        hmacd.slice(0, 8),
+        iv,
+        ciphered,
+    ]);
+
+    return toBase64Encode.toString("base64");
+}
+
+function createSaltedKey(key: string, salt: crypto.BinaryLike) {
+    return crypto.pbkdf2Sync(
+        key,
+        salt,
+        1000, // iterations
+        16, // key length (in bytes, vs Java's bits)
+        "SHA1", // hash
+    );
+}
+
 // ======= public interface ===============================
 
 export class PrimeApi {
@@ -65,7 +131,7 @@ export class PrimeApi {
         registrationData.device_name = `${this.deviceNameBase}%DUPE_STRATEGY_2ND%`;
         body.registration_data = registrationData;
 
-        const frc = await this.generateFrcCookies();
+        const frc = await generateFrcCookies(this.deviceId, this.language);
         if (frc !== null) {
             debug(`generated cookies: ${frc}`);
             body.user_context_map = {
@@ -125,66 +191,6 @@ export class PrimeApi {
         return this.language;
     }
 
-    public async generateFrcCookies() {
-        const cookies = JSON.stringify({
-            ApplicationName: APP_NAME,
-            ApplicationVersion: APP_VERSION,
-            DeviceLanguage: this.language,
-            DeviceName: "walleye/google/Pixel 2",
-            DeviceOSVersion: "google/walleye/walleye:8.1.0/OPM1.171019.021/4565141:user/release-keys",
-            IpAddress: getIpAddress(),
-            ScreenHeightPixels: "1920",
-            ScreenWidthPixels: "1280",
-            TimeZone: "-04:00",
-        });
-
-        debug("generating FRC cookies from: ", cookies);
-
-        // gzip
-        const zipped: Buffer = await new Promise((resolve, reject) => {
-            gzip(cookies, {}, (e, result) => {
-                if (e) reject(e);
-                else resolve(result);
-            });
-        });
-
-        // Cipher instance = Cipher.getInstance("AES/CBC/PKCS5Padding");
-        // instance.init(1, b(str2, "AES/CBC/PKCS7Padding"));
-        const key = this.createSaltedKey("AES/CBC/PKCS7Padding");
-        const iv = crypto.randomBytes(16);
-        const cipher = crypto.createCipheriv("aes-128-cbc", key, iv);
-
-        // toByteArray = instance.doFinal(toByteArray);
-        // byte[] iv = instance.getIV();
-        const cipheredBase = cipher.update(zipped);
-        const ciphered = Buffer.concat([cipheredBase, cipher.final()]);
-
-        // Mac instance2 = Mac.getInstance("HmacSHA256");
-        // instance2.init(b(str2, "HmacSHA256"));
-        // instance2.update(iv);
-        // instance2.update(toByteArray);
-        // byte[] doFinal = instance2.doFinal();
-        const hmac = crypto.createHmac("sha256", this.createSaltedKey("HmacSHA256"));
-        hmac.update(iv);
-        hmac.update(ciphered);
-        const hmacd = hmac.digest();
-
-        // byte[] bArr = new byte[(toByteArray.length + 25)];
-        // bArr[0] = (byte) 0;
-        // System.arraycopy(doFinal, 0, bArr, 1, 8);
-        // System.arraycopy(iv, 0, bArr, 9, 16);
-        // System.arraycopy(toByteArray, 0, bArr, 25, toByteArray.length);
-        const toBase64Encode = Buffer.concat([
-            Buffer.of(0),
-            hmacd.slice(0, 8),
-            iv,
-            ciphered,
-        ]);
-
-        // return Base64.encodeToString(bArr, 2);
-        return toBase64Encode.toString("base64");
-    }
-
     private buildUrl(path: string): string {
         const domain = this.apiDomain();
         return `https://${domain}/${path}`;
@@ -192,25 +198,6 @@ export class PrimeApi {
 
     private apiDomain(): string {
         return this.opts.apiDomain || DEFAULT_API_DOMAIN;
-    }
-
-    private createSaltedKey(salt: crypto.BinaryLike) {
-        // return new SecretKeySpec(
-        //      SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1")
-        //          .generateSecret(
-        //              new PBEKeySpec(
-        //                  str.toCharArray(), str2.getBytes("UTF-8"), 1000, 128
-        //              )
-        //          ).getEncoded(),
-        //          "AES"
-        //      );
-        return crypto.pbkdf2Sync(
-            this.deviceId,
-            salt,
-            1000, // iterations
-            16, // key length (in bytes, vs Java's bits)
-            "SHA1", // hash
-        );
     }
 
     private generateDeviceData(): any {

--- a/src/apps/prime/api.ts
+++ b/src/apps/prime/api.ts
@@ -87,7 +87,11 @@ export class PrimeApi {
         }
 
         debug("login successful = ", success);
+        debug("cookies = ", success.tokens.website_cookies);
         return {
+            cookies: success.tokens.website_cookies.map((c: any) => {
+                return `${c.Name}=${c.Value}`;
+            }).join("; "),
             refreshToken: success.tokens.bearer.refresh_token,
         };
     }

--- a/src/apps/prime/config.ts
+++ b/src/apps/prime/config.ts
@@ -1,0 +1,13 @@
+export interface IPrimeApiOpts {
+    deviceId?: string;
+    apiDomain?: string;
+}
+
+export interface IPrimeOpts extends IPrimeApiOpts {
+    // TODO
+    cookies: string;
+    refreshToken: string;
+
+    marketplaceId?: string;
+    apiDomain?: string;
+}

--- a/src/apps/prime/index.ts
+++ b/src/apps/prime/index.ts
@@ -1,10 +1,14 @@
 import _debug from "debug";
 const debug = _debug("babbling:PrimeApp");
 
+import crypto from "crypto";
+import os from "os";
+import { gzip } from "zlib";
+
 import request from "request-promise-native";
+import generateRandomUUID from "uuid/v4";
 
 import { generateDeviceId } from "chakram-ts/dist/util";
-import os from "os";
 
 import { ICastSession, IDevice } from "../../cast";
 import { BaseApp, MEDIA_NS } from "../base";
@@ -13,7 +17,10 @@ import { awaitMessageOfType } from "../util";
 const APP_ID = "17608BC8";
 const AUTH_NS = "urn:x-cast:com.amazon.primevideo.cast";
 
-const DEFAULT_DOMAIN = "api.amazon.com";
+const DEFAULT_API_DOMAIN = "api.amazon.com";
+
+const APP_NAME = "com.amazon.avod.thirdpartyclient";
+const APP_VERSION = "253188041";
 
 export interface IPrimeOpts {
     // TODO
@@ -21,13 +28,15 @@ export interface IPrimeOpts {
     deviceId?: string;
     marketplaceId?: string;
     refreshToken?: string;
-    domain?: string;
+    apiDomain?: string;
 }
 
 export class PrimeApp extends BaseApp {
 
     private readonly deviceId: string;
     private readonly opts: IPrimeOpts;
+
+    private readonly language = "en-US";
 
     constructor(device: IDevice, options: IPrimeOpts) {
         super(device, {
@@ -52,8 +61,8 @@ export class PrimeApp extends BaseApp {
         }
 
         debug("registered! ensureCastSession... ");
-        const s = await this.ensureCastSession();
         return;
+        const s = await this.ensureCastSession();
 
         debug("request playback:", titleId);
         s.send({
@@ -91,6 +100,63 @@ export class PrimeApp extends BaseApp {
         debug(ms.status[0].media);
     }
 
+    public async generateFrcCookies() {
+        const cookies = JSON.stringify({
+            ApplicationName: APP_NAME,
+            ApplicationVersion: APP_VERSION,
+            DeviceLanguage: this.language,
+            DeviceName: "ro.hardware/google/pixel",
+            DeviceOSVersion: "google/bullhead/bullhead:6.0.1/MTC20F/3031278:user/release-key",
+            ScreenHeightPixels: "1920",
+            ScreenWidthPixels: "1280",
+            TimeZone: "-04:00",
+        });
+
+        // gzip
+        const zipped: Buffer = await new Promise((resolve, reject) => {
+            gzip(cookies, {}, (e, result) => {
+                if (e) reject(e);
+                else resolve(result);
+            });
+        });
+
+        // Cipher instance = Cipher.getInstance("AES/CBC/PKCS5Padding");
+        // instance.init(1, b(str2, "AES/CBC/PKCS7Padding"));
+        const key = this.createSaltedKey("AES/CBC/PKCS7Padding");
+        const iv = crypto.randomBytes(16);
+        const cipher = crypto.createCipheriv("aes-128-cbc", key, iv);
+
+        // toByteArray = instance.doFinal(toByteArray);
+        // byte[] iv = instance.getIV();
+        cipher.update(zipped);
+        const ciphered = cipher.final();
+
+        // Mac instance2 = Mac.getInstance("HmacSHA256");
+        // instance2.init(b(str2, "HmacSHA256"));
+        // instance2.update(iv);
+        // instance2.update(toByteArray);
+        // byte[] doFinal = instance2.doFinal();
+        const hmac = crypto.createHmac("sha256", this.createSaltedKey("HmacSHA256"));
+        hmac.update(iv);
+        hmac.update(ciphered);
+        const hmacd = hmac.digest();
+
+        // byte[] bArr = new byte[(toByteArray.length + 25)];
+        // bArr[0] = (byte) 0;
+        // System.arraycopy(doFinal, 0, bArr, 1, 8);
+        // System.arraycopy(iv, 0, bArr, 9, 16);
+        // System.arraycopy(toByteArray, 0, bArr, 25, toByteArray.length);
+        const toBase64Encode = Buffer.concat([
+            Buffer.of(0),
+            hmacd.slice(0, 8),
+            iv,
+            ciphered,
+        ]);
+
+        // return Base64.encodeToString(bArr, 2);
+        return toBase64Encode.toString("base64");
+    }
+
     private message(type: string, extra: any = {}) {
         return Object.assign({
             deviceId: this.deviceId,
@@ -113,25 +179,50 @@ export class PrimeApp extends BaseApp {
         }));
 
         // await checkedRequest(session, this.message("AmIRegistered"));
+
+        // await this.applySettings(session);
     }
+
+    // private async applySettings(session: ICastSession) {
+    //     await checkedRequest(session, this.message("ApplySettings", {
+    //         settings: {
+    //             autoplayNextEpisode: true,
+    //             locale: this.language,
+    //         },
+    //     }));
+    // }
 
     private async generatePreAuthorizedLinkCode() {
         debug(`generating pre-authorized link code...`);
-        const response = await request.post({
-            body: {
-                auth_data: {
-                    access_token: this.opts.refreshToken,
-                },
-                code_data: {
-                    domain: "Device",
+        const body: any = {
+            auth_data: {
+                access_token: this.opts.refreshToken,
+            },
+            code_data: {
+                domain: "Device",
 
-                    app_name: "defaultAppName",
-                    app_version: "42",
-                    device_model: "Pixel",
-                    device_serial: this.deviceId,
-                    device_type: "android",
-                    os_version: "22",
-                },
+                app_name: APP_NAME,
+                app_version: APP_VERSION,
+                device_model: "pixel",
+                device_serial: this.deviceId,
+                device_type: "android",
+                os_version: "22",
+            },
+            scopes: ["aiv:full"],
+        };
+
+        const frc = await this.generateFrcCookies();
+        if (frc !== null) {
+            body.user_context_map = {
+                frc,
+            };
+        }
+
+        const response = await request.post({
+            body,
+            headers: {
+                "x-amzn-identity-auth-domain": this.apiDomain(),
+                "x-amzn-requestid": generateRandomUUID(),
             },
             json: true,
             url: this.buildUrl("/auth/create/code"),
@@ -141,13 +232,37 @@ export class PrimeApp extends BaseApp {
             throw new Error(JSON.stringify(response));
         }
 
+        // TODO cache for response.expires_in seconds?
         debug(`generated pre-authorized link code: ${response.code}`);
         return response.code;
     }
 
     private buildUrl(path: string): string {
-        const domain = this.opts.domain || DEFAULT_DOMAIN;
+        const domain = this.apiDomain();
         return `https://${domain}/${path}`;
+    }
+
+    private apiDomain(): string {
+        return this.opts.apiDomain || DEFAULT_API_DOMAIN;
+    }
+
+    private createSaltedKey(salt: crypto.BinaryLike) {
+        // return new SecretKeySpec(
+        //      SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1")
+        //          .generateSecret(
+        //              new PBEKeySpec(
+        //                  str.toCharArray(), str2.getBytes("UTF-8"), 1000, 128
+        //              )
+        //          ).getEncoded(),
+        //          "AES"
+        //      );
+        return crypto.pbkdf2Sync(
+            this.deviceId,
+            salt,
+            1000, // iterations
+            16, // key length (/ 8, apparently)
+            "SHA1", // hash
+        );
     }
 
 }
@@ -155,12 +270,12 @@ export class PrimeApp extends BaseApp {
 async function castRequest(session: ICastSession, message: any) {
     const responseType = message.type + "Response";
     session.send(message);
-    return awaitMessageOfType(session, responseType);
+    return awaitMessageOfType(session, responseType, 15_000);
 }
 
 async function checkedRequest(session: ICastSession, message: any) {
     const resp = await castRequest(session, message);
-    if (resp.error) {
+    if (resp.error && resp.error.code) {
         throw resp.error;
     }
     debug(" -> ", resp);

--- a/src/apps/prime/index.ts
+++ b/src/apps/prime/index.ts
@@ -1,6 +1,8 @@
 import _debug from "debug";
 const debug = _debug("babbling:PrimeApp");
 
+import request from "request-promise-native";
+
 import { generateDeviceId } from "chakram-ts/dist/util";
 import os from "os";
 
@@ -11,12 +13,15 @@ import { awaitMessageOfType } from "../util";
 const APP_ID = "17608BC8";
 const AUTH_NS = "urn:x-cast:com.amazon.primevideo.cast";
 
+const DEFAULT_DOMAIN = "api.amazon.com";
+
 export interface IPrimeOpts {
     // TODO
     cookies: string;
     deviceId?: string;
     marketplaceId?: string;
-    token?: string;
+    refreshToken?: string;
+    domain?: string;
 }
 
 export class PrimeApp extends BaseApp {
@@ -39,7 +44,7 @@ export class PrimeApp extends BaseApp {
 
     public async play(titleId: string) {
         const session = await this.joinOrRunNamespace(AUTH_NS);
-        const resp = await request(session, this.message("AmIRegistered"));
+        const resp = await castRequest(session, this.message("AmIRegistered"));
         debug("registered=", resp);
 
         if (resp.error && resp.error.code === "NotRegistered") {
@@ -95,27 +100,66 @@ export class PrimeApp extends BaseApp {
     }
 
     private async register(session: ICastSession) {
-        debug("register with id", this.deviceId, "opts=", this.opts);
+        debug("register with id", this.deviceId);
+
+        const preAuthorizedLinkCode =
+            await this.generatePreAuthorizedLinkCode();
+
         await checkedRequest(session, this.message("Register", {
             // TODO load this from chakram
             marketplaceId: this.opts.marketplaceId,
 
-            preAuthorizedLinkCode: "",
+            preAuthorizedLinkCode,
         }));
 
-        await checkedRequest(session, this.message("AmIRegistered"));
+        // await checkedRequest(session, this.message("AmIRegistered"));
+    }
+
+    private async generatePreAuthorizedLinkCode() {
+        debug(`generating pre-authorized link code...`);
+        const response = await request.post({
+            body: {
+                auth_data: {
+                    access_token: this.opts.refreshToken,
+                },
+                code_data: {
+                    domain: "Device",
+
+                    app_name: "defaultAppName",
+                    app_version: "42",
+                    device_model: "Pixel",
+                    device_serial: this.deviceId,
+                    device_type: "android",
+                    os_version: "22",
+                },
+            },
+            json: true,
+            url: this.buildUrl("/auth/create/code"),
+        });
+
+        if (!response.code) {
+            throw new Error(JSON.stringify(response));
+        }
+
+        debug(`generated pre-authorized link code: ${response.code}`);
+        return response.code;
+    }
+
+    private buildUrl(path: string): string {
+        const domain = this.opts.domain || DEFAULT_DOMAIN;
+        return `https://${domain}/${path}`;
     }
 
 }
 
-async function request(session: ICastSession, message: any) {
+async function castRequest(session: ICastSession, message: any) {
     const responseType = message.type + "Response";
     session.send(message);
     return awaitMessageOfType(session, responseType);
 }
 
 async function checkedRequest(session: ICastSession, message: any) {
-    const resp = await request(session, message);
+    const resp = await castRequest(session, message);
     if (resp.error) {
         throw resp.error;
     }

--- a/src/apps/prime/index.ts
+++ b/src/apps/prime/index.ts
@@ -26,6 +26,7 @@ export interface IPrimeOpts {
     // TODO
     cookies: string;
     deviceId?: string;
+    deviceType?: string;
     marketplaceId?: string;
     refreshToken?: string;
     apiDomain?: string;
@@ -34,6 +35,7 @@ export interface IPrimeOpts {
 export class PrimeApp extends BaseApp {
 
     private readonly deviceId: string;
+    private readonly deviceType: string;
     private readonly opts: IPrimeOpts;
 
     private readonly language = "en-US";
@@ -49,6 +51,7 @@ export class PrimeApp extends BaseApp {
             APP_ID,
             os.hostname(),
         );
+        this.deviceType = options.deviceType || "android";
     }
 
     public async play(titleId: string) {
@@ -87,6 +90,7 @@ export class PrimeApp extends BaseApp {
         let ms;
         do {
             ms = await Promise.race([
+                awaitMessageOfType(s, "CLOSE"),
                 awaitMessageOfType(s, "LOAD_FAILED"),
                 awaitMessageOfType(s, "MEDIA_STATUS"),
             ]);
@@ -205,7 +209,7 @@ export class PrimeApp extends BaseApp {
                 app_version: APP_VERSION,
                 device_model: "pixel",
                 device_serial: this.deviceId,
-                device_type: "android",
+                device_type: this.deviceType,
                 os_version: "22",
             },
             scopes: ["aiv:full"],
@@ -275,7 +279,7 @@ async function castRequest(session: ICastSession, message: any) {
 
 async function checkedRequest(session: ICastSession, message: any) {
     const resp = await castRequest(session, message);
-    if (resp.error && resp.error.code) {
+    if (resp.error) {
         throw resp.error;
     }
     debug(" -> ", resp);

--- a/src/apps/prime/index.ts
+++ b/src/apps/prime/index.ts
@@ -1,11 +1,16 @@
 import _debug from "debug";
 const debug = _debug("babbling:PrimeApp");
 
+import { ChakramApi, ContentType, IBaseObj, ISeason } from "chakram-ts";
+
+import { IPlayableOptions, IQueryResult } from "../../app";
 import { ICastSession, IDevice } from "../../cast";
 import { BaseApp, MEDIA_NS } from "../base";
 import { awaitMessageOfType } from "../util";
 import { PrimeApi } from "./api";
 import { IPrimeOpts } from "./config";
+
+export { IPrimeOpts } from "./config";
 
 const APP_ID = "17608BC8";
 const AUTH_NS = "urn:x-cast:com.amazon.primevideo.cast";
@@ -15,7 +20,44 @@ const DEFAULT_MARKETPLACE_ID = "ATVPDKIKX0DER";
 
 export class PrimeApp extends BaseApp {
 
+    public static ownsUrl(url: string) {
+        // TODO other domains
+        return url.includes("amazon.com");
+    }
+
+    public static async createPlayable(
+        url: string,
+        options: IPrimeOpts,
+    ) {
+        const titleId = pickTitleIdFromUrl(url);
+        if (!titleId) {
+            throw new Error(`Unsure how to play ${url}`);
+        }
+
+        const api = new ChakramApi(options.cookies);
+        const info = await api.getTitleInfo(titleId);
+        debug("titleInfo = ", info);
+
+        return playableFromObj(info);
+    }
+
+    public static async *queryByTitle(
+        title: string,
+        opts: IPrimeOpts,
+    ): AsyncIterable<IQueryResult> {
+        const api = new ChakramApi(opts.cookies);
+        for (const result of await api.search(title)) {
+            yield {
+                appName: "PrimeApp",
+                playable: playableFromObj(result),
+                title: cleanTitle(result.title),
+                url: "https://www.amazon.com/video/detail/" + result.id,
+            };
+        }
+    }
+
     private readonly api: PrimeApi;
+    private readonly chakram: ChakramApi;
     private readonly refreshToken: string;
     private readonly marketplaceId: string;
 
@@ -27,12 +69,18 @@ export class PrimeApp extends BaseApp {
 
         this.refreshToken = options.refreshToken;
         this.api = new PrimeApi(options);
+        this.chakram = new ChakramApi(options.cookies);
 
         // TODO derive this somehow?
         this.marketplaceId = options.marketplaceId || DEFAULT_MARKETPLACE_ID;
     }
 
-    public async play(titleId: string) {
+    public async play(
+        titleId: string,
+        { startTime }: {
+            startTime?: number,
+        },
+    ) {
         const session = await this.joinOrRunNamespace(AUTH_NS);
         const resp = await castRequest(session, this.message("AmIRegistered"));
         debug("registered=", resp);
@@ -45,7 +93,7 @@ export class PrimeApp extends BaseApp {
         const s = await this.ensureCastSession();
 
         debug("request playback:", titleId);
-        s.send({
+        const request: any = {
             autoplay: true,
             customData: {
                 deviceId: this.api.deviceId,
@@ -62,7 +110,14 @@ export class PrimeApp extends BaseApp {
             },
             sessionId: s.id,
             type: "LOAD",
-        });
+        };
+
+        if (startTime !== undefined) {
+            request.startTime = startTime;
+        }
+
+        // send LOAD request!
+        s.send(request);
 
         let ms;
         do {
@@ -79,6 +134,19 @@ export class PrimeApp extends BaseApp {
 
         } while (!ms.status.length);
         debug(ms.status[0].media);
+    }
+
+    /**
+     * Attempt to resume playback of the series with the given ID
+     */
+    public async resumeSeries(
+        id: string,
+    ) {
+        const toResume = await this.chakram.guessResumeInfo(id);
+
+        await this.play(toResume.id, {
+            startTime: toResume.startTimeSeconds,
+        });
     }
 
     private message(type: string, extra: any = {}) {
@@ -129,4 +197,45 @@ async function checkedRequest(session: ICastSession, message: any) {
     }
     debug(" -> ", resp);
     return resp;
+}
+
+function playableFromObj(info: IBaseObj) {
+    if (info.type === ContentType.SERIES) {
+        debug("playable for series", info.id);
+        return async (app: PrimeApp) => app.resumeSeries(info.id);
+    } else if (info.type === ContentType.SEASON) {
+        // probably they want to resume the series
+        const season = info as ISeason;
+        if (season.series) {
+            const seriesId = season.series.id;
+            debug("playable for series", seriesId, "given season", seriesId);
+            return async (app: PrimeApp) => app.resumeSeries(seriesId);
+        }
+    }
+
+    debug("playable for title", info.id);
+    return async (app: PrimeApp, opts: IPlayableOptions) => {
+        if (opts.resume === false) {
+            await app.play(info.id, { startTime: 0 });
+        } else {
+            await app.play(info.id, {});
+        }
+    };
+}
+
+function pickTitleIdFromUrl(url: string) {
+    const m1 = url.match(/video\/detail\/([^\/]+)/);
+    if (m1) {
+        return m1[1];
+    }
+
+    const m2 = url.match(/gp\/product\/([^\/\?]+)/);
+    if (m2) {
+        return m2[1];
+    }
+}
+
+function cleanTitle(original: string) {
+    // including this suffix confuses title-matching
+    return original.replace("(4K UHD)", "").trim();
 }

--- a/src/apps/prime/index.ts
+++ b/src/apps/prime/index.ts
@@ -1,0 +1,91 @@
+import _debug from "debug";
+const debug = _debug("PrimeApp");
+
+import { generateDeviceId } from "chakram-ts/dist/util";
+import os from "os";
+
+import { ICastSession, IDevice } from "../../cast";
+import { BaseApp, MEDIA_NS } from "../base";
+import { awaitMessageOfType } from "../util";
+
+const APP_ID = "17608BC8";
+const AUTH_NS = "urn:x-cast:com.amazon.primevideo.cast";
+
+export interface IPrimeOpts {
+    // TODO
+    cookies: string;
+    deviceId?: string;
+}
+
+export class PrimeApp extends BaseApp {
+
+    private readonly deviceId: string;
+
+    constructor(device: IDevice, options: IPrimeOpts) {
+        super(device, {
+            appId: APP_ID,
+            sessionNs: MEDIA_NS,
+        });
+
+        this.deviceId = options.deviceId || generateDeviceId(
+            APP_ID,
+            os.hostname(),
+        );
+    }
+
+    public async play(titleId: string) {
+        const session = await this.joinOrRunNamespace(AUTH_NS);
+        const resp = await request(session, this.message("AmIRegistered"));
+        debug("registered=", resp);
+
+        if (resp.error && resp.error.code === "NotRegistered") {
+            await this.register(session);
+        }
+
+        const s = await this.ensureCastSession();
+        s.send({
+            autoplay: true,
+            customData: {
+                videoMaterialType: "Feature", // TODO ?
+            },
+            media: {
+                contentId: titleId,
+                contentType: "video/mp4",
+                streamType: "BUFFERED",
+            },
+            sessionId: s.id,
+            type: "LOAD",
+        });
+
+    }
+
+    private message(type: string, extra: any = {}) {
+        return Object.assign({
+            deviceId: this.deviceId,
+            type,
+        }, extra);
+    }
+
+    private async register(session: ICastSession) {
+        debug("register with id", this.deviceId);
+        const resp = await request(session, this.message("Register", {
+            // TODO load this from chakram?
+            marketplaceId: "ATVPDKIKX0DER",
+
+            // TODO how do we get this?
+            preAuthorizedLinkCode: undefined,
+        }));
+        debug(" -> ", resp);
+
+        if (resp.error) {
+            throw resp.error;
+        }
+    }
+
+}
+
+async function request(session: ICastSession, message: any) {
+    const responseType = message.type + "Response";
+    session.send(message);
+    return awaitMessageOfType(session, responseType);
+}

--- a/src/apps/util.ts
+++ b/src/apps/util.ts
@@ -2,13 +2,14 @@ import { Callback, ICastSession, IDevice } from "../cast";
 
 export const awaitMessageOfType = (
     session: ICastSession, type: string,
+    timeoutMs: number = 5000,
 ): Promise<any> => new Promise((resolve, reject) => {
     let onMessage: (m: any) => any;
 
     const timeoutId = setTimeout(() => {
         session.removeListener("message", onMessage);
         reject(new Error("Timeout waiting for " + type));
-    }, 5000);
+    }, timeoutMs);
 
     onMessage = message => {
         if (message.type === type) {

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -10,11 +10,11 @@ import findByTitle from "./commands/find";
 import scanForDevices from "./commands/scan";
 import searchByTitle from "./commands/search";
 
-import authorizePrime from "./commands/auth/prime";
+import { login as primeLogin } from "./commands/auth/prime";
 
 // type-safe conditional import via reference elision
 import * as AuthCommand from "./commands/auth";
-import { IAuthOpts } from "./commands/auth";
+import { IAuthOpts } from "./commands/auth/config";
 let authCommandModule: typeof AuthCommand;
 
 let canAutoConfigure = false;
@@ -129,13 +129,14 @@ if (canAutoConfigure) {
 }
 
 parser.command(
-    "auth:prime <code>", `Auth with prime`, args => {
-        return withConfig(args).positional("code", {
-            describe: `Auth code`,
-            type: "string",
-        }).demand("code");
+    "auth:prime <email>", `Auth with prime`, args => {
+        return withConfig(args)
+            .positional("email", {
+                describe: `Email address`,
+                type: "string",
+            }).demand("email");
     }, async argv => {
-        await authorizePrime(argv.code);
+        await primeLogin(argv, argv.email);
     },
 );
 

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -10,6 +10,8 @@ import findByTitle from "./commands/find";
 import scanForDevices from "./commands/scan";
 import searchByTitle from "./commands/search";
 
+import authorizePrime from "./commands/auth/prime";
+
 // type-safe conditional import via reference elision
 import * as AuthCommand from "./commands/auth";
 import { IAuthOpts } from "./commands/auth";
@@ -125,6 +127,17 @@ if (canAutoConfigure) {
         },
     );
 }
+
+parser.command(
+    "auth:prime <code>", `Auth with prime`, args => {
+        return withConfig(args).positional("code", {
+            describe: `Auth code`,
+            type: "string",
+        }).demand("code");
+    }, async argv => {
+        await authorizePrime(argv.code);
+    },
+);
 
 parser.help()
     .demandCommand(1);

--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -9,6 +9,7 @@ import { consoleWrite, prompt } from "./util";
 
 import { getAppConstructors } from "../config";
 import { IConfigSource, ILocalStorageSource, isConfigurable } from "../model";
+import { IAuthOpts } from "./auth/config";
 import { readConfig, writeConfig } from "./config";
 
 class ChromagnonSource implements IConfigSource {
@@ -62,11 +63,6 @@ export class ConfigExtractor {
 
         return config;
     }
-}
-
-export interface IAuthOpts {
-    config: string;
-    ignoreErrors: boolean;
 }
 
 export async function authenticate(opts: IAuthOpts) {

--- a/src/cli/commands/auth/config.ts
+++ b/src/cli/commands/auth/config.ts
@@ -1,0 +1,4 @@
+export interface IAuthOpts {
+    config: string;
+    ignoreErrors?: boolean;
+}

--- a/src/cli/commands/auth/prime.ts
+++ b/src/cli/commands/auth/prime.ts
@@ -1,29 +1,8 @@
-import request from "request-promise-native";
 
 import { PrimeApi } from "../../../apps/prime/api";
 import { configInPath } from "../config";
 import { consoleWrite, prompt } from "../util";
 import { IAuthOpts } from "./config";
-
-const OAUTH_URL = "https://api.amazon.com/auth/o2/token";
-const CLIENT_ID = "amzn1.application-oa2-client.1a59cedc41344e8b9d7c7529a9352254";
-const CLIENT_SECRET = "215c8685fc27ad5938e2d2275e9c55b63f3c529cbe2ce03cdf0e7cdb4c90cfc8";
-
-// DEPRECATED, probably
-export default async function authorize(code: string) {
-    // nop
-    const response = await request.post({
-        url: OAUTH_URL,
-
-        form: {
-            client_id: CLIENT_ID,
-            client_secret: CLIENT_SECRET,
-            code,
-            grant_type: "authorization_code",
-        },
-    });
-    return response;
-}
 
 export async function login(opts: IAuthOpts, email: string) {
     const password = await prompt("password (not stored): ");

--- a/src/cli/commands/auth/prime.ts
+++ b/src/cli/commands/auth/prime.ts
@@ -1,5 +1,10 @@
 import request from "request-promise-native";
 
+import { PrimeApi } from "../../../apps/prime/api";
+import { configInPath } from "../config";
+import { consoleWrite, prompt } from "../util";
+import { IAuthOpts } from "./config";
+
 const OAUTH_URL = "https://api.amazon.com/auth/o2/token";
 const CLIENT_ID = "amzn1.application-oa2-client.1a59cedc41344e8b9d7c7529a9352254";
 const CLIENT_SECRET = "215c8685fc27ad5938e2d2275e9c55b63f3c529cbe2ce03cdf0e7cdb4c90cfc8";
@@ -20,6 +25,15 @@ export default async function authorize(code: string) {
     return response;
 }
 
-export async function login(email: string, password: string) {
-    // TODO
+export async function login(opts: IAuthOpts, email: string) {
+    const password = await prompt("password (not stored): ");
+    if (!password) {
+        consoleWrite("Prime Video auth canceled");
+        return;
+    }
+
+    const api = new PrimeApi();
+    const config = await api.login(email, password);
+    await configInPath(opts.config, ["PrimeApp"], config);
+    consoleWrite("Success!");
 }

--- a/src/cli/commands/auth/prime.ts
+++ b/src/cli/commands/auth/prime.ts
@@ -1,0 +1,20 @@
+import request from "request-promise-native";
+
+const OAUTH_URL = "https://api.amazon.com/auth/o2/token";
+const CLIENT_ID = "amzn1.application-oa2-client.1a59cedc41344e8b9d7c7529a9352254";
+const CLIENT_SECRET = "215c8685fc27ad5938e2d2275e9c55b63f3c529cbe2ce03cdf0e7cdb4c90cfc8";
+
+export default async function authorize(code: string) {
+    // nop
+    const response = await request.post({
+        url: OAUTH_URL,
+
+        form: {
+            client_id: CLIENT_ID,
+            client_secret: CLIENT_SECRET,
+            code,
+            grant_type: "authorization_code",
+        },
+    });
+    console.log(response);
+}

--- a/src/cli/commands/auth/prime.ts
+++ b/src/cli/commands/auth/prime.ts
@@ -4,6 +4,7 @@ const OAUTH_URL = "https://api.amazon.com/auth/o2/token";
 const CLIENT_ID = "amzn1.application-oa2-client.1a59cedc41344e8b9d7c7529a9352254";
 const CLIENT_SECRET = "215c8685fc27ad5938e2d2275e9c55b63f3c529cbe2ce03cdf0e7cdb4c90cfc8";
 
+// DEPRECATED, probably
 export default async function authorize(code: string) {
     // nop
     const response = await request.post({
@@ -16,5 +17,9 @@ export default async function authorize(code: string) {
             grant_type: "authorization_code",
         },
     });
-    console.log(response);
+    return response;
+}
+
+export async function login(email: string, password: string) {
+    // TODO
 }

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -16,7 +16,7 @@ export async function writeConfig(path: string, obj: any) {
     return fs.writeFile(path, JSON.stringify(obj, null, "  "));
 }
 
-export function updateConfig(obj: any, path: string[], newValue: string) {
+export function setPath(obj: any, path: string[], newValue: string) {
     if (path.length === 0) throw new Error("Invalid path");
 
     let o = obj;
@@ -43,6 +43,16 @@ export async function config(configPath: string, key: string, value?: string) {
 
     // tslint:disable-next-line no-console
     console.log(`${key}: `, json[key]);
+}
+
+export async function configInPath(
+    configFilePath: string,
+    objPath: string[],
+    value: any,
+) {
+    const json = await readConfig(configFilePath);
+    setPath(json, objPath, value);
+    await writeConfig(configFilePath, json);
 }
 
 export async function unconfig(configPath: string, key: string) {

--- a/src/cli/commands/util.ts
+++ b/src/cli/commands/util.ts
@@ -2,7 +2,7 @@
 
 import readline from "readline";
 
-export async function prompt(promptText: string) {
+export async function prompt(promptText: string): Promise<string> {
     return new Promise(resolve => {
         const prompter = readline.createInterface({
             input: process.stdin,

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -7,7 +7,7 @@ import pathlib from "path";
 import { IApp, IAppConstructor, IPlayerEnabledConstructor, Opts } from "../app";
 import { BabblerBaseApp } from "../apps/babbler/base";
 import { IWritableToken } from "../token";
-import { readConfig, updateConfig, writeConfig } from "./commands/config";
+import { configInPath, readConfig } from "./commands/config";
 
 export const DEFAULT_CONFIG_PATH = pathlib.join(
     os.homedir(),
@@ -83,9 +83,7 @@ class AppConfigToken implements IWritableToken {
         debug("update", this.tokenPath, " <- ", newValue);
 
         this.value = newValue;
-        const config = await readConfig(this.configPath);
-        const updated = updateConfig(config, this.tokenPath, newValue);
-        await writeConfig(this.configPath, updated);
+        await configInPath(this.configPath, this.tokenPath, newValue);
     }
 
     public toJSON(): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export { PlayerBuilder } from "./player";
 export { HboGoApp, IHboGoOpts, IHboGoPlayOptions } from "./apps/hbogo";
 export { HuluApp, IHuluOpts } from "./apps/hulu";
 export { BabblerPrimeApp, IBabblerPrimeOpts } from "./apps/babbler-prime";
+export { PrimeApp, IPrimeOpts } from "./apps/prime";
 export { YoutubeApp, IYoutubeOpts } from "./apps/youtube";
 
 // for building apps that won't be merged into core:

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ export { ChromecastDevice } from "./device";
 export { PlayerBuilder } from "./player";
 export { HboGoApp, IHboGoOpts, IHboGoPlayOptions } from "./apps/hbogo";
 export { HuluApp, IHuluOpts } from "./apps/hulu";
-export { PrimeApp, IPrimeOpts } from "./apps/prime";
+export { BabblerPrimeApp, IBabblerPrimeOpts } from "./apps/babbler-prime";
 export { YoutubeApp, IYoutubeOpts } from "./apps/youtube";
 
 // for building apps that won't be merged into core:

--- a/test/cli/commands/config-test.ts
+++ b/test/cli/commands/config-test.ts
@@ -1,17 +1,17 @@
 import * as chai from "chai";
 
-import { updateConfig } from "../../../src/cli/commands/config";
+import { setPath } from "../../../src/cli/commands/config";
 
 chai.should();
 
-describe("updateConfig", () => {
+describe("setPath", () => {
     it("handles 1-length paths", () => {
-        updateConfig({ name: "serenity" }, ["name"], "mreynolds")
+        setPath({ name: "serenity" }, ["name"], "mreynolds")
             .should.deep.equal({ name: "mreynolds" });
     });
 
     it("handles multi-length paths", () => {
-        updateConfig({ name: "serenity" }, ["type", "name"], "firefly")
+        setPath({ name: "serenity" }, ["type", "name"], "firefly")
             .should.deep.equal({
                 name: "serenity",
                 type: {


### PR DESCRIPTION
The babbler approach was neat but for whatever reason the video always started to hang around the 7 minute mark. This PR uses the new, official Amazon Prime Video chromecast app for reliable video casting! Auth cannot be done automatically, unfortunately, but it's quite easy to manually auth with the `auth:prime` command.

Future work can explore figuring out the user's `marketplaceId` and associated API endpoints to add support for non-US customers, but for now I'm exhausted just getting this to finally cooperate.

Shoutouts to Apple for still letting you trust user-added certs at root-level on iOS, enabling `mitmproxy`, without which I was quite stuck and wildly frustrated for a long time. Shoutouts to Google for blocking this ability on newer devices—even in developer mode—for reasons that *totally* make sense. Last shoutouts to Amazon for not making the app x86 compatible, making it practically impossible to use an emulator to try to observe traffic.