### PR TITLE
Improve Prime search results by restricting to *playable* titles

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -64,6 +64,12 @@ export interface IQueryResult {
 
     /** @internal */
     playable: IPlayable<any>;
+
+    /**
+     * If `true`, it is a preferred result from the service,
+     * perhaps bookmarked or in a "watch list"
+     */
+    isPreferred?: boolean;
 }
 
 /**

--- a/src/app.ts
+++ b/src/app.ts
@@ -66,6 +66,11 @@ export interface IQueryResult {
     playable: IPlayable<any>;
 
     /**
+     * If `true`, the item can be played, but will have ads
+     */
+    hasAds?: boolean;
+
+    /**
      * If `true`, it is a preferred result from the service,
      * perhaps bookmarked or in a "watch list"
      */

--- a/src/apps/prime/channel.ts
+++ b/src/apps/prime/channel.ts
@@ -9,6 +9,7 @@ import { PrimeApi } from "./api";
 // NOTE: this sure looks like a circular dependency, but we're just
 // importing it for the type definition
 import { IPrimeOpts, PrimeApp } from ".";
+import { AvailabilityType, IAvailability } from "./model";
 
 export class PrimePlayerChannel implements IPlayerChannel<PrimeApp> {
 
@@ -39,6 +40,7 @@ export class PrimePlayerChannel implements IPlayerChannel<PrimeApp> {
             yield {
                 appName: "PrimeApp",
                 desc: result.desc,
+                hasAds: isAvailableOnlyWithAds(result.availability),
                 isPreferred: result.isInWatchlist || result.isPurchased,
                 playable: playableFromSearchResult(result),
                 title: result.title,
@@ -47,6 +49,19 @@ export class PrimePlayerChannel implements IPlayerChannel<PrimeApp> {
         }
     }
 
+}
+
+function isAvailableOnlyWithAds(availability: IAvailability[]) {
+    const canPlayWithAds = -1 !== availability.findIndex(a =>
+        a.type === AvailabilityType.FREE_WITH_ADS);
+    if (!canPlayWithAds) return false;
+
+    // we can play with ads, so it's *only* available with ads iff we don't find
+    // another availability type
+    return -1 === availability.findIndex(a =>
+        a.type === AvailabilityType.PRIME
+            || a.type === AvailabilityType.OTHER_SUBSCRIPTION
+            || a.type === AvailabilityType.OWNED);
 }
 
 function pickTitleIdFromUrl(url: string) {

--- a/src/apps/prime/channel.ts
+++ b/src/apps/prime/channel.ts
@@ -93,9 +93,10 @@ function playableFromObj(info: IBaseObj) {
 
 function playableFromSearchResult(result: IBaseObj) {
     if (
-        result.type !== ContentType.SERIES
-        && result.type !== ContentType.MOVIE
+        result.type === ContentType.SERIES
+        || result.type === ContentType.MOVIE
     ) {
+        // we can use SERIES or MOVIE results directly
         return playableFromObj(result);
     }
 

--- a/src/apps/prime/model.ts
+++ b/src/apps/prime/model.ts
@@ -1,5 +1,8 @@
+import { ContentType } from "chakram-ts";
 
 export enum AvailabilityType {
+    FREE_WITH_ADS,
+    OTHER_SUBSCRIPTION,
     OWNED,
     PRIME,
 
@@ -18,4 +21,16 @@ export interface ISearchOpts {
      * already purchased) will be returned.
      */
     onlyPlayable?: boolean;
+}
+
+export interface ISearchResult {
+    availability: IAvailability[];
+    cover?: string;
+    desc?: string;
+    id: string;
+    isPurchased?: boolean;
+    isInWatchlist?: boolean;
+    title: string;
+    type: ContentType;
+    watchUrl: string;
 }

--- a/src/apps/prime/model.ts
+++ b/src/apps/prime/model.ts
@@ -1,0 +1,21 @@
+
+export enum AvailabilityType {
+    OWNED,
+    PRIME,
+
+    PURCHASABLE,
+    RENTABLE,
+}
+
+export interface IAvailability {
+    type: AvailabilityType;
+}
+
+export interface ISearchOpts {
+    /**
+     * If true (default) only items that are immediately available for
+     * playing somehow (either through an active subscription or if
+     * already purchased) will be returned.
+     */
+    onlyPlayable?: boolean;
+}

--- a/src/cli/commands/find.ts
+++ b/src/cli/commands/find.ts
@@ -13,6 +13,10 @@ export interface IFindByTitleOpts {
 
 const MAX_CANDIDATES = 30;
 
+function lerp(from: number, to: number, fraction: number) {
+    return (1 - fraction) * from + fraction * to;
+}
+
 export async function pickBestMatchForTitle(
     candidates: AsyncIterable<IQueryResult>,
     title: string,
@@ -33,7 +37,15 @@ export async function pickBestMatchForTitle(
             return item;
         }
 
-        const score = 1 / distance;
+        let score = 1 / distance;
+        if (item.isPreferred) {
+            score = lerp(score, 1, 0.5);
+        } else if (item.hasAds) {
+            // in case another service has the same title
+            // but without ads
+            score = lerp(score, 0, 0.5);
+        }
+
         if (score > bestScore) {
             bestScore = score;
             best = item;
@@ -61,5 +73,5 @@ export default async function findByTitle(opts: IFindByTitleOpts) {
 
     consoleWrite(`Playing ${best.title} via ${best.appName}`);
 
-    await player.play(best);
+    // await player.play(best);
 }

--- a/src/cli/commands/find.ts
+++ b/src/cli/commands/find.ts
@@ -73,5 +73,5 @@ export default async function findByTitle(opts: IFindByTitleOpts) {
 
     consoleWrite(`Playing ${best.title} via ${best.appName}`);
 
-    // await player.play(best);
+    await player.play(best);
 }


### PR DESCRIPTION
The previous method was much simpler, but there was no way of filtering
out titles that weren't available, or that were unpurchased. Now, only
*actually* playable items should be returned from PrimeApp.queryByTitle

This also introduces (but does not yet utilize) the concept of "preferred" query results, which could be used to influence cross-provider playable resolution.