### PR TITLE
Improve PrimeApp resume reliability

### DIFF
--- a/src/apps/prime/api.ts
+++ b/src/apps/prime/api.ts
@@ -345,6 +345,10 @@ export class PrimeApi {
 
         const info: {
             episodes?: IEpisode[],
+            movie?: {
+                title: string,
+                titleId: string,
+            },
             series?: {
                 title: string,
                 titleId: string,
@@ -386,6 +390,13 @@ export class PrimeApi {
             }
 
             info.episodes = episodes;
+        }
+
+        if (resource.contentType === "MOVIE") {
+            info.movie = {
+                title: resource.title,
+                titleId: resource.titleId,
+            };
         }
 
         return info;

--- a/src/apps/prime/api.ts
+++ b/src/apps/prime/api.ts
@@ -94,6 +94,30 @@ function createSaltedKey(key: string, salt: crypto.BinaryLike) {
     );
 }
 
+// ======= internal types =================================
+
+interface IEpisode {
+    episodeNumber: number;
+    seasonId: string;
+    seasonNumber: number;
+    title: string;
+    titleId: string;
+
+    completedAfter: number;
+    runtimeSeconds: number;
+    watchedSeconds: number;
+}
+
+interface IWatchNextItem {
+    title: string;
+    titleId: string;
+
+    completedAfter: number;
+    resumeTitleId?: string;
+    runtimeSeconds: number;
+    watchedSeconds: number;
+}
+
 // ======= public interface ===============================
 
 export class PrimeApi {
@@ -244,8 +268,146 @@ export class PrimeApi {
         }
     }
 
+    public async guessResumeInfo(titleId: string) {
+        const [ titleInfo, { watchNext } ] = await Promise.all([
+            this.getTitleInfo(titleId),
+            this.getHomePage(),
+        ]);
+
+        if (!titleInfo.series) {
+            // TODO: resume movie? maybe amazon handles this for us
+            debug("title is not a series");
+            return;
+        }
+
+        if (!watchNext) {
+            debug("no watchNext data");
+            return;
+        }
+
+        debug(titleInfo);
+        for (const info of watchNext) {
+            debug("Check:", info.titleId, ": ", info.title);
+            if (
+                info.titleId === titleId
+                || (
+                    titleInfo.seasonIds
+                    && titleInfo.seasonIds.has(info.titleId)
+                )
+            ) {
+                debug(titleInfo.series.title, "found in watchNext:", info);
+                return this.resolveNext(info);
+            }
+        }
+
+        debug(`couldn't find ${titleInfo.series.title} in watchNext`);
+    }
+
+    public async getHomePage() {
+        const { resource } = await this.swiftApiRequest(
+            "/cdp/mobile/getDataByTransform/v1/dv-ios/home/v1.js",
+        );
+
+        const info: {
+            watchNext?: IWatchNextItem[],
+        } = {};
+
+        const watchNextSection = resource.collections.filter((c: any) =>
+            c.title === "Watch next",
+        )[0];
+        if (watchNextSection) {
+            info.watchNext = watchNextSection.items.map((item: any) => ({
+                title: item.title,
+                titleId: item.titleId,
+
+                completedAfter: item.playAndProgress.completedAfter,
+                resumeTitleId: item.playAndProgress.titleId,
+                runtimeSeconds: item.playAndProgress.runtimeSeconds,
+                watchedSeconds: item.playAndProgress.watchedSeconds,
+            }));
+        }
+
+        return info;
+    }
+
+    public async getTitleInfo(titleId: string) {
+        const { resource } = await this.swiftApiRequest(
+            "/cdp/mobile/getDataByTransform/v1/android/atf/v3.jstl",
+            {
+                itemId: titleId,
+            },
+        );
+
+        const info: {
+            episodes?: IEpisode[],
+            series?: {
+                title: string,
+                titleId: string,
+            },
+            seasonIds?: Set<string>,
+            selectedEpisode?: IEpisode,
+        } = {};
+
+        if (resource.show) {
+            info.series = {
+                title: resource.show.title,
+                titleId: resource.show.titleId,
+            };
+        }
+
+        if (resource.seasons) {
+            info.seasonIds = new Set<string>(resource.seasons.map((s: any) =>
+                s.titleId,
+            ));
+        }
+
+        if (resource.episodes) {
+            const episodes = resource.episodes.map((e: any) => ({
+                episodeNumber: e.episodeNumber,
+                seasonId: e.season.titleId,
+                seasonNumber: e.seasonNumber,
+                title: e.title,
+                titleId: e.titleId,
+
+                isSelected: e.selectedEpisode,
+
+                completedAfter: e.completedAfterSeconds,
+                runtimeSeconds: e.runtimeSeconds,
+                watchedSeconds: e.timecodeSeconds,
+            }));
+            const selected = episodes.filter((e: any) => e.isSelected);
+            if (selected.length) {
+                info.selectedEpisode = selected[0];
+            }
+
+            info.episodes = episodes;
+        }
+
+        return info;
+    }
+
     public getLanguage() {
         return this.language;
+    }
+
+    private async resolveNext(info: IWatchNextItem) {
+        if (!info.watchedSeconds || info.watchedSeconds < info.completedAfter) {
+            return info;
+        }
+
+        // TODO fetch episodes of this season and pick the next one
+        debug("watchNext is already complete; moving on...");
+        const seasonTitle = await this.getTitleInfo(info.titleId);
+
+        if (seasonTitle.episodes) {
+            const lastIndex = seasonTitle.episodes.findIndex(e => e.titleId === info.resumeTitleId);
+            if (lastIndex < seasonTitle.episodes.length - 1) {
+                return seasonTitle.episodes[lastIndex + 1];
+            }
+        }
+
+        // otherwise, fallback to what we had
+        return info;
     }
 
     private buildUrl(path: string): string {
@@ -358,11 +520,13 @@ export class PrimeApi {
                 continue;
             }
 
+            debug("raw item <-", item);
             const id = item.actionPress.analytics.pageTypeId;
             yield {
                 availability,
                 id,
                 title: cleanTitle(itemTitle),
+                titleId: item.titleId,
                 type,
                 watchUrl: `https://www.amazon.com/dp/${id}/?autoplay=1`,
             };
@@ -401,6 +565,7 @@ export class PrimeApi {
                 id,
                 isInWatchlist: item.decoratedTitle.computed.simple.IS_IN_WATCHLIST,
                 title: cleanTitle(item.decoratedTitle.catalog.title),
+                titleId: item.titleId,
                 type,
                 watchUrl: `https://www.amazon.com/dp/${id}/?autoplay=1`,
             };

--- a/src/apps/prime/channel.ts
+++ b/src/apps/prime/channel.ts
@@ -34,7 +34,7 @@ export class PrimePlayerChannel implements IPlayerChannel<PrimeApp> {
     public async *queryByTitle(
         title: string,
         opts: IPrimeOpts,
-    ): AsyncIterable<IQueryResult> {
+    ): AsyncIterable<IQueryResult & { titleId: string }> {
         const api = new PrimeApi(opts);
         for await (const result of api.search(title)) {
             yield {
@@ -44,6 +44,7 @@ export class PrimePlayerChannel implements IPlayerChannel<PrimeApp> {
                 isPreferred: result.isInWatchlist || result.isPurchased,
                 playable: playableFromSearchResult(result),
                 title: result.title,
+                titleId: result.titleId,
                 url: "https://www.amazon.com/gp/video/detail/" + result.id,
             };
         }

--- a/src/apps/prime/channel.ts
+++ b/src/apps/prime/channel.ts
@@ -9,7 +9,7 @@ import { PrimeApi } from "./api";
 // NOTE: this sure looks like a circular dependency, but we're just
 // importing it for the type definition
 import { IPrimeOpts, PrimeApp } from ".";
-import { AvailabilityType, IAvailability } from "./model";
+import { AvailabilityType, IAvailability, ISearchResult } from "./model";
 
 export class PrimePlayerChannel implements IPlayerChannel<PrimeApp> {
 
@@ -107,13 +107,15 @@ function playableFromObj(info: IBaseObj) {
     };
 }
 
-function playableFromSearchResult(result: IBaseObj) {
-    if (
-        result.type === ContentType.SERIES
-        || result.type === ContentType.MOVIE
-    ) {
-        // we can use SERIES or MOVIE results directly
+function playableFromSearchResult(result: ISearchResult) {
+    if (result.type === ContentType.MOVIE) {
+        // we can use MOVIE results directly
         return playableFromObj(result);
+    }
+
+    if (result.titleId) {
+        return async (app: PrimeApp, opts: IPlayableOptions) =>
+            app.resumeSeriesByTitleId(result.titleId);
     }
 
     // we have to resolve the series, first, because the ID we have resolves

--- a/src/apps/prime/index.ts
+++ b/src/apps/prime/index.ts
@@ -51,6 +51,7 @@ export class PrimeApp extends BaseApp {
             startTime?: number,
         },
     ) {
+        debug("play: join", AUTH_NS);
         const session = await this.joinOrRunNamespace(AUTH_NS);
         const resp = await castRequest(session, this.message("AmIRegistered"));
         debug("registered=", resp);
@@ -117,6 +118,24 @@ export class PrimeApp extends BaseApp {
         await this.play(toResume.id, {
             startTime: toResume.startTimeSeconds,
         });
+    }
+
+    /**
+     * Attempt to resume playback of the series with the given ID
+     */
+    public async resumeSeriesByTitleId(
+        titleId: string,
+    ) {
+        const toResume = await this.api.guessResumeInfo(titleId);
+        if (toResume) {
+            debug("resume: ", toResume);
+            return this.play(toResume.titleId, {
+                startTime: toResume.watchedSeconds,
+            });
+        }
+
+        debug("no resume info found; play:", titleId);
+        return this.play(titleId, {});
     }
 
     private message(type: string, extra: any = {}) {

--- a/src/apps/prime/model.ts
+++ b/src/apps/prime/model.ts
@@ -31,6 +31,7 @@ export interface ISearchResult {
     isPurchased?: boolean;
     isInWatchlist?: boolean;
     title: string;
+    titleId: string;
     type: ContentType;
     watchUrl: string;
 }


### PR DESCRIPTION
The default APIs would apparently not suggest a cross-season resume action (sigh) and thanks to Amazon's insistence that each season be a separately searchable entity (instead of the series itself) we have to jump through some hoops to find the right season/episode to resume.

This currently will only correctly resume if the title is in the first page of "watch next" results; more investigation will be needed to figure out how to paginate through "watch next" to find older titles.