### PR TITLE
Support querying for "recommended" media 

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -58,6 +58,11 @@ export interface IQueryResult {
     desc?: string;
 
     /**
+     * Image URL for cover art, if available
+     */
+    cover?: string;
+
+    /**
      * Playable URL for this entity, if available
      */
     url?: string;

--- a/src/app.ts
+++ b/src/app.ts
@@ -98,9 +98,16 @@ export interface IPlayerChannel<TSelf extends IApp> {
     createPlayable(url: string): Promise<IPlayable<AppFor<TSelf>>>;
 
     /**
-     *
+     * Search for {@see Player.play}'able media by title
      */
     queryByTitle?(title: string): AsyncIterable<IQueryResult>;
+
+    /**
+     * Search for {@see Player.play}'able media per the source
+     * apps' recommendations. Could be (but not necessarily)
+     * based on recency
+     */
+    queryRecommended?(): AsyncIterable<IQueryResult>;
 
 }
 

--- a/src/apps/hulu/api.ts
+++ b/src/apps/hulu/api.ts
@@ -5,10 +5,13 @@ import request from "request-promise-native";
 
 import { IHuluOpts } from "./config";
 
+const DISCOVER_BASE = "https://discover.hulu.com/content/v4";
+
 // tslint:disable
-const ENTITY_DISCOVER_URL = "https://discover.hulu.com/content/v4/entity/deeplink?schema=2&referral_host=www.hulu.com";
-const SEARCH_URL = "https://discover.hulu.com/content/v4/search/entity?language=en&device_context_id=2&limit=64&include_offsite=false&schema=2&referral_host=www.hulu.com";
-const SERIES_HUB_URL_FORMAT = "https://discover.hulu.com/content/v4/hubs/series/%s/?schema=2&referral_host=www.hulu.com";
+const ENTITY_DISCOVER_URL = DISCOVER_BASE + "/entity/deeplink?schema=2&referral_host=www.hulu.com";
+const SEARCH_URL = DISCOVER_BASE + "/search/entity?language=en&device_context_id=2&limit=64&include_offsite=false&schema=2&referral_host=www.hulu.com";
+const SERIES_HUB_URL_FORMAT = DISCOVER_BASE + "/hubs/series/%s/?schema=2&referral_host=www.hulu.com";
+const RECENT_URL = DISCOVER_BASE + "/hubs/watch-history?schema=9&referral_host=production"
 
 const USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36";
 
@@ -149,6 +152,20 @@ export class HuluApi {
         debug(`Next entity for series ${seriesId}:`, entity);
 
         return entity;
+    }
+
+    public async *fetchRecent() {
+        const { components } = await request({
+            headers: this.generateHeaders(),
+            json: true,
+            url: RECENT_URL,
+        });
+        if (!(components && components.length)) return;
+
+        const { items/* , pagination */ } = components[0];
+        for (const item of items) {
+            yield item;
+        }
     }
 
     private generateHeaders() {

--- a/src/apps/prime/channel.ts
+++ b/src/apps/prime/channel.ts
@@ -70,6 +70,7 @@ export class PrimePlayerChannel implements IPlayerChannel<PrimeApp> {
                 playable: playableFromTitleId(result.titleId),
                 title: result.title,
                 titleId: result.titleId,
+                url: "https://watch.amazon.com/detail?gti=" + result.titleId,
             };
         }
     }

--- a/src/apps/prime/channel.ts
+++ b/src/apps/prime/channel.ts
@@ -60,6 +60,20 @@ export class PrimePlayerChannel implements IPlayerChannel<PrimeApp> {
         }
     }
 
+    public async *queryRecommended(): AsyncIterable<IQueryResult & { titleId: string }> {
+        const api = new PrimeApi(this.options);
+        const watchNext = await api.watchNextItems();
+        if (!watchNext) return;
+
+        for await (const result of watchNext) {
+            yield {
+                appName: "PrimeApp",
+                playable: playableFromTitleId(result.titleId),
+                title: result.title,
+                titleId: result.titleId,
+            };
+        }
+    }
 }
 
 function isAvailableOnlyWithAds(availability: IAvailability[]) {

--- a/src/apps/prime/channel.ts
+++ b/src/apps/prime/channel.ts
@@ -62,12 +62,11 @@ export class PrimePlayerChannel implements IPlayerChannel<PrimeApp> {
 
     public async *queryRecommended(): AsyncIterable<IQueryResult & { titleId: string }> {
         const api = new PrimeApi(this.options);
-        const watchNext = await api.watchNextItems();
-        if (!watchNext) return;
-
-        for await (const result of watchNext) {
+        for await (const result of api.nextUpItems()) {
             yield {
                 appName: "PrimeApp",
+                cover: result.cover,
+                desc: result.desc,
                 playable: playableFromTitleId(result.titleId),
                 title: result.title,
                 titleId: result.titleId,

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -7,6 +7,7 @@ import cast from "./commands/cast";
 import { config, unconfig } from "./commands/config";
 import mediaControlCommand from "./commands/do";
 import findByTitle from "./commands/find";
+import getRecommendations from "./commands/recommend";
 import scanForDevices from "./commands/scan";
 import searchByTitle from "./commands/search";
 
@@ -91,6 +92,12 @@ parser.command(
             type: "string",
         }).demand("title");
     }, searchByTitle,
+);
+
+parser.command(
+    "recommend", `List recommendations`, args => {
+        return withConfig(args);
+    }, getRecommendations,
 );
 
 parser.command(

--- a/src/cli/commands/recommend.ts
+++ b/src/cli/commands/recommend.ts
@@ -1,0 +1,16 @@
+import { ChromecastDevice } from "../../device";
+import { PlayerBuilder } from "../../player";
+
+import { formatQueryResults } from "./search";
+
+export interface IGetRecommendationsOpts {
+    config: string;
+}
+
+export default async function getRecommendations(opts: IGetRecommendationsOpts) {
+    const builder = await PlayerBuilder.autoInflate(opts.config);
+    builder.addDevice(new ChromecastDevice("_unused_"));
+    const player = builder.build();
+
+    await formatQueryResults(player.queryRecommended());
+}

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -1,3 +1,4 @@
+import { IQueryResult } from "../../app";
 import { ChromecastDevice } from "../../device";
 import { PlayerBuilder } from "../../player";
 import { consoleWrite } from "./util";
@@ -27,6 +28,10 @@ export default async function searchByTitle(opts: ISearchByTitleOpts) {
 
     const results = player.queryByTitle(opts.title);
 
+    await formatQueryResults(results);
+}
+
+export async function formatQueryResults(results: AsyncIterable<IQueryResult>) {
     let found = 0;
     for await (const match of results) {
         ++found;

--- a/src/player.ts
+++ b/src/player.ts
@@ -11,7 +11,7 @@ import {
     OptionsFor,
     Opts,
 } from "./app";
-import { mergeAsyncIterables } from "./async";
+import { interleaveAsyncIterables, mergeAsyncIterables } from "./async";
 import { importConfig } from "./cli/config";
 import { ChromecastDevice } from "./device";
 
@@ -135,7 +135,7 @@ class Player {
             }
         });
 
-        return mergeAsyncIterables(iterables);
+        return interleaveAsyncIterables(iterables);
     }
 
     private async playOnEachDevice(

--- a/src/player.ts
+++ b/src/player.ts
@@ -113,6 +113,31 @@ class Player {
         return mergeAsyncIterables(iterables);
     }
 
+    /**
+     * Get an AsyncIterable representing playables from across all
+     * configured apps. Each result can be passed directly to `play`.
+     *
+     * @param onError Handler for when an app encounters an error. By
+     *                default, the error will just be thrown eagerly,
+     *                but you may prefer to simply log the error and
+     *                allow the other apps to provide their results
+     */
+    public queryRecommended(
+        onError: (app: string, e: Error) => void = (app, e) => { throw e; },
+    ) {
+        const iterables = this.apps.map(async function*(app) {
+            if (!app.channel.queryRecommended) return;
+
+            try {
+                yield *app.channel.queryRecommended();
+            } catch (e) {
+                onError(app.appConstructor.name, e);
+            }
+        });
+
+        return mergeAsyncIterables(iterables);
+    }
+
     private async playOnEachDevice(
         configured: IConfiguredApp<any>,
         playable: IPlayable<any>,

--- a/test/async-test.ts
+++ b/test/async-test.ts
@@ -1,6 +1,6 @@
 import * as chai from "chai";
 
-import { mergeAsyncIterables, toArray } from "../src/async";
+import { interleaveAsyncIterables, mergeAsyncIterables, toArray } from "../src/async";
 
 chai.should();
 
@@ -60,5 +60,59 @@ describe("mergeAsyncIterables", () => {
         ]));
 
         array.should.deep.equal([0, 10, 11, 1, 12, 2]);
+    });
+});
+
+describe("interleaveAsyncIterables", () => {
+    it("Respects original order", async () => {
+        const array = await toArray(interleaveAsyncIterables([
+            (async function*() {
+                yield 0;
+                yield 1;
+                yield 2;
+            })(),
+        ]));
+
+        array.should.deep.equal([0, 1, 2]);
+    });
+
+    it("Interleaves all", async () => {
+        const array = await toArray(interleaveAsyncIterables([
+            (async function*() {
+                yield 0;
+                yield 2;
+                yield 4;
+            })(),
+
+            (async function*() {
+                yield 1;
+                yield 3;
+                yield 5;
+            })(),
+        ]));
+
+        array.should.deep.equal([ 0, 1, 2, 3, 4, 5 ]);
+    });
+
+    it("Interleaves all with sleeps", async () => {
+        const array = await toArray(interleaveAsyncIterables([
+            (async function*() {
+                yield 0;
+                await sleep(10);
+                yield 2;
+                await sleep(10);
+                yield 4;
+            })(),
+
+            (async function*() {
+                yield 1;
+                await sleep(10);
+                yield 3;
+                await sleep(10);
+                yield 5;
+            })(),
+        ]));
+
+        array.should.deep.equal([ 0, 1, 2, 3, 4, 5 ]);
     });
 });


### PR DESCRIPTION
We do not currently implement this for HboGo or Youtube; the former doesn't seem to have a comparable interface, and the latter is probably noisy for most use cases. Future work could of course revisit this.

Hulu's results are currently for the "keep watching" list; Amazon's are in "up next" which is *mostly* recently watched stuff, but not entirely. I think Amazon's results fit pretty well here, but it may make sense in the future to include other things in Hulu's home page as "recommended." It may also make sense to have a separate "recently watched" query API, but Amazon may or may not have a pure API for that—maybe that's okay?