### PR TITLE
Support querying for and playing specific episodes in a series

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -123,7 +123,7 @@ export interface IPlayerChannel<TSelf extends IApp> {
      * Find a specific {@see Player.play}'able episode for the
      * given {@see IQueryResult}.
      */
-    findEpisodeFor(
+    findEpisodeFor?(
         item: IQueryResult,
         query: IEpisodeQuery,
     ): Promise<IEpisodeQueryResult | undefined>;

--- a/src/app.ts
+++ b/src/app.ts
@@ -120,6 +120,15 @@ export interface IPlayerChannel<TSelf extends IApp> {
     createPlayable(url: string): Promise<IPlayable<AppFor<TSelf>>>;
 
     /**
+     * Find a specific {@see Player.play}'able episode for the
+     * given {@see IQueryResult}.
+     */
+    findEpisodeFor(
+        item: IQueryResult,
+        query: IEpisodeQuery,
+    ): Promise<IEpisodeQueryResult | undefined>;
+
+    /**
      * Search for {@see Player.play}'able media by title
      */
     queryByTitle?(title: string): AsyncIterable<IQueryResult>;

--- a/src/app.ts
+++ b/src/app.ts
@@ -82,6 +82,23 @@ export interface IQueryResult {
     isPreferred?: boolean;
 }
 
+export interface IEpisodeQueryResult extends IQueryResult {
+    seriesTitle: string;
+}
+
+export interface ISeasonAndEpisodeQuery {
+    episodeIndex: number;
+    seasonIndex: number;
+}
+
+/**
+ * IEpisodeQuery is a map describing how to locate a specific
+ * episode to play within a series. Not all providers will
+ * support all query types; in such cases, their channel should
+ * return an empty set
+ */
+export type IEpisodeQuery = ISeasonAndEpisodeQuery;
+
 /**
  * The IPlayerChannel interface is a high-level, unified means of
  * interacting with a particular app and its service.
@@ -106,6 +123,12 @@ export interface IPlayerChannel<TSelf extends IApp> {
      * Search for {@see Player.play}'able media by title
      */
     queryByTitle?(title: string): AsyncIterable<IQueryResult>;
+
+    /**
+     * Search for {@see Player.play}'able media by title, requesting a specific
+     * episode in the matching series
+     */
+    queryEpisodeForTitle?(title: string, query: IEpisodeQuery): AsyncIterable<IEpisodeQueryResult>;
 
     /**
      * Search for {@see Player.play}'able media per the source

--- a/src/apps/hbogo/channel.ts
+++ b/src/apps/hbogo/channel.ts
@@ -56,6 +56,8 @@ export class HboGoPlayerChannel implements IPlayerChannel<HboGoApp> {
         }
 
         const urn = urnFromUrl(item.url!);
+        if (entityTypeFromUrn(urn) !== "series") return; // cannot have it
+
         const episodes = await this.api.getEpisodesForSeries(urn);
         const episode = episodes.get(query);
         if (!episode) return;
@@ -84,20 +86,4 @@ export class HboGoPlayerChannel implements IPlayerChannel<HboGoApp> {
         }
     }
 
-    public async *queryEpisodeForTitle(
-        title: string,
-        query: IEpisodeQuery,
-    ): AsyncIterable<IEpisodeQueryResult> {
-        for await (const result of this.queryByTitle(title)) {
-            const urn = urnFromUrl(result.url!);
-            if (entityTypeFromUrn(urn) !== "series") {
-                continue;
-            }
-
-            const episode = await this.findEpisodeFor(result, query);
-            if (episode) {
-                yield episode;
-            }
-        }
-    }
 }

--- a/src/apps/hbogo/channel.ts
+++ b/src/apps/hbogo/channel.ts
@@ -4,6 +4,7 @@ import {
     IPlayerChannel,
     IQueryResult,
 } from "../../app";
+import { EpisodeResolver } from "../../util/episode-resolver";
 
 import { HboGoApp, IHboGoOpts } from ".";
 import { entityTypeFromUrn, HboGoApi } from "./api";
@@ -58,8 +59,10 @@ export class HboGoPlayerChannel implements IPlayerChannel<HboGoApp> {
         const urn = urnFromUrl(item.url!);
         if (entityTypeFromUrn(urn) !== "series") return; // cannot have it
 
-        const episodes = await this.api.getEpisodesForSeries(urn);
-        const episode = episodes.get(query);
+        const resolver = new EpisodeResolver({
+            container: () => this.api.getEpisodesForSeries(urn),
+        });
+        const episode = await resolver.query(query);
         if (!episode) return;
 
         const url = "https://play.hbogo.com/" + episode.urn;

--- a/src/apps/hulu/api.ts
+++ b/src/apps/hulu/api.ts
@@ -3,6 +3,8 @@ const debug = _debug("babbling:hulu:api");
 
 import request from "request-promise-native";
 
+import { EpisodeResolver } from "../../util/episode-resolver";
+
 import { IHuluOpts } from "./config";
 
 const DISCOVER_BASE = "https://discover.hulu.com/content/v4";
@@ -141,6 +143,25 @@ export class HuluApi {
             // similarly, if we're prompted to "get related" it's not on hulu
             && !item.actions.get_related,
         );
+    }
+
+    public episodeResolver(seriesId: string) {
+        const api = this;
+        return new EpisodeResolver<IHuluEpisode>({
+            async *episodesInSeason(season: number) {
+                let page: string | undefined;
+                do {
+                    const { items, nextPage } = await api.episodesInSeason(
+                        seriesId,
+                        season + 1,
+                        page,
+                    );
+
+                    yield items;
+                    page = nextPage;
+                } while (page);
+            },
+        });
     }
 
     public async episodesInSeason(

--- a/src/apps/hulu/api.ts
+++ b/src/apps/hulu/api.ts
@@ -148,12 +148,12 @@ export class HuluApi {
     public episodeResolver(seriesId: string) {
         const api = this;
         return new EpisodeResolver<IHuluEpisode>({
-            async *episodesInSeason(season: number) {
+            async *episodesInSeason(seasonIndex: number) {
                 let page: string | undefined;
                 do {
                     const { items, nextPage } = await api.episodesInSeason(
                         seriesId,
-                        season + 1,
+                        seasonIndex + 1,
                         page,
                     );
 

--- a/src/apps/hulu/channel.ts
+++ b/src/apps/hulu/channel.ts
@@ -7,10 +7,9 @@ import {
     IPlayerChannel,
     IQueryResult,
 } from "../../app";
-import { EpisodeResolver } from "../../util/episode-resolver";
 
 import { HuluApp, IHuluOpts } from ".";
-import { HuluApi, IHuluEpisode, supportedEntityTypes } from "./api";
+import { HuluApi, supportedEntityTypes } from "./api";
 
 const UUID_LENGTH = 36;
 
@@ -60,23 +59,7 @@ export class HuluPlayerChannel implements IPlayerChannel<HuluApp> {
         const url = item.url!;
         const seriesId = url.substring(url.lastIndexOf("/") + 1);
 
-        const resolver = new EpisodeResolver<IHuluEpisode>({
-            async *episodesInSeason(season: number) {
-                let page: string | undefined;
-                do {
-                    const { items, nextPage } = await api.episodesInSeason(
-                        seriesId,
-                        season + 1,
-                        page,
-                    );
-
-                    yield items;
-                    page = nextPage;
-                } while (page);
-            },
-        });
-
-        const episode = await resolver.query(query);
+        const episode = await api.episodeResolver(seriesId).query(query);
         if (!episode) return;
 
         return {

--- a/src/apps/prime/api.ts
+++ b/src/apps/prime/api.ts
@@ -122,7 +122,7 @@ interface IWatchNextItem {
 }
 
 type PromiseType<T extends Promise<any>> = T extends Promise<infer R> ? R : never;
-type ITitleInfo = PromiseType<ReturnType<PrimeApi["getTitleInfo"]>>;
+export type ITitleInfo = PromiseType<ReturnType<PrimeApi["getTitleInfo"]>>;
 
 // ======= public interface ===============================
 
@@ -303,8 +303,8 @@ export class PrimeApi {
             if (
                 info.titleId === titleId
                 || (
-                    titleInfo.seasonIds
-                    && titleInfo.seasonIds.has(info.titleId)
+                    titleInfo.seasonIdSet
+                    && titleInfo.seasonIdSet.has(info.titleId)
                 )
             ) {
                 debug(titleInfo.series.title, "found in watchNext:", info);
@@ -405,7 +405,8 @@ export class PrimeApi {
                 title: string,
                 titleId: string,
             },
-            seasonIds?: Set<string>,
+            seasonIds?: string[],
+            seasonIdSet?: Set<string>,
             selectedEpisode?: IEpisode,
         } = {};
 
@@ -417,9 +418,10 @@ export class PrimeApi {
         }
 
         if (resource.seasons) {
-            info.seasonIds = new Set<string>(resource.seasons.map((s: any) =>
+            info.seasonIds = resource.seasons.map((s: any) =>
                 s.titleId,
-            ));
+            );
+            info.seasonIdSet = new Set<string>(info.seasonIds);
         }
 
         if (resource.episodes) {

--- a/src/apps/prime/api/episode-capabilities.ts
+++ b/src/apps/prime/api/episode-capabilities.ts
@@ -1,0 +1,61 @@
+import _debug from "debug";
+const debug = _debug("babbling:prime:episodes");
+
+import { IEpisodeBase } from "../../../util/episode-container";
+import { IEpisodeCapabilities } from "../../../util/episode-resolver";
+
+import { ITitleInfo, PrimeApi } from "../api";
+
+export interface IPrimeEpisode extends IEpisodeBase {
+    titleId: string;
+}
+
+export class PrimeEpisodeCapabilities implements IEpisodeCapabilities<IPrimeEpisode> {
+    constructor(
+        private readonly api: PrimeApi,
+        private readonly seriesTitleId: string,
+    ) {}
+
+    public async *episodesInSeason(seasonIndex: number) {
+        const seasonNumber = seasonIndex + 1;
+        const info = await this.api.getTitleInfo(this.seriesTitleId);
+        if (!info.series) return;
+
+        debug(`fetching season ${seasonNumber} of ${info.series.title}`);
+
+        // do we already have the right season?
+        if (
+            info.episodes
+            && info.episodes.length
+            && info.episodes[0].seasonNumber === seasonNumber
+        ) {
+            debug(`already have season ${seasonNumber}`);
+            yield mapEpisodes(info);
+            return;
+        }
+
+        // need to fetch the appropriate season, if possible
+        if (!info.seasonIds || info.seasonIds.length <= seasonIndex) return;
+        debug(`seasons of ${info.series.title} = ${info.seasonIds}`);
+
+        const seasonId = info.seasonIds[seasonIndex];
+        debug(`fetching season#${seasonIndex}: ${seasonId}`);
+        const season = await this.api.getTitleInfo(seasonId);
+
+        if (season.episodes) {
+            yield mapEpisodes(season);
+        }
+    }
+
+}
+
+function mapEpisodes(info: ITitleInfo) {
+    return info.episodes!
+        .filter(raw => raw.episodeNumber >= 1)
+        .map((raw, index) => ({
+            indexInSeason: raw.episodeNumber - 1,
+            season: raw.seasonNumber - 1,
+            title: raw.title,
+            titleId: raw.titleId,
+        }));
+}

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -71,7 +71,15 @@ parser.command(
         return withDevice(withConfig(args)).positional("title", {
             describe: "The title to play",
             type: "string",
-        }).demand("title");
+        }).demand("title")
+            .option("season", {
+                describe: "The season number to play. If `episode` is not provided, plays the first episode of that season.",
+                type: "number",
+            })
+            .option("episode", {
+                describe: "The episode number to play. Must not be provided without `season`.",
+                type: "number",
+            });
     }, findByTitle,
 );
 

--- a/src/player.ts
+++ b/src/player.ts
@@ -92,6 +92,15 @@ class Player {
         );
     }
 
+    public async findEpisodeFor(
+        item: IQueryResult,
+        query: IEpisodeQuery,
+    ): Promise<IEpisodeQueryResult | undefined> {
+        const configured = findAppNamed(this.apps, item.appName);
+        if (!configured.channel.findEpisodeFor) return;
+        return configured.channel.findEpisodeFor(item, query);
+    }
+
     /**
      * Get an AsyncIterable representing playables from across all
      * configured apps. Each result can be passed directly to `play`.

--- a/src/util/episode-container.ts
+++ b/src/util/episode-container.ts
@@ -1,0 +1,47 @@
+import { IEpisodeQuery } from "../app";
+
+export interface IEpisodeBase {
+    season: number;
+    indexInSeason: number;
+}
+
+interface ISeason<TEpisode extends IEpisodeBase> {
+    index: number;
+    episodes: TEpisode[];
+}
+
+export class EpisodeContainer<TEpisode extends IEpisodeBase> {
+    private allEpisodes: TEpisode[] = [];
+    private seasons: Array<ISeason<TEpisode>> = [];
+
+    public add(episode: TEpisode) {
+        this.allEpisodes.push(episode);
+        while (episode.season >= this.seasons.length) {
+            this.seasons.push({
+                episodes: [],
+                index: this.seasons.length,
+            });
+        }
+
+        this.seasons[episode.season].episodes.push(episode);
+    }
+
+    public get(query: IEpisodeQuery) {
+        if (
+            query.seasonIndex !== undefined
+            && query.episodeIndex !== undefined
+        ) {
+            return this.byIndices(query.seasonIndex, query.episodeIndex);
+        }
+    }
+
+    private byIndices(season: number, episode: number) {
+        if (season >= this.seasons.length) return;
+
+        const seasonObj = this.seasons[season];
+        if (episode >= seasonObj.episodes.length) return;
+
+        return seasonObj.episodes[episode];
+    }
+
+}

--- a/src/util/episode-resolver.ts
+++ b/src/util/episode-resolver.ts
@@ -8,7 +8,7 @@ export interface IEpisodeCapabilities<TEpisode extends IEpisodeBase> {
     /**
      * Yields batches of episodes, to support paginated implementations
      */
-    episodesInSeason?(season: number): AsyncIterable<TEpisode[]>;
+    episodesInSeason?(seasonIndex: number): AsyncIterable<TEpisode[]>;
 }
 
 export class EpisodeResolver<TEpisode extends IEpisodeBase> {

--- a/src/util/episode-resolver.ts
+++ b/src/util/episode-resolver.ts
@@ -1,0 +1,42 @@
+import { IEpisodeQuery } from "../app";
+
+import { EpisodeContainer, IEpisodeBase } from "./episode-container";
+
+export interface IEpisodeCapabilities<TEpisode extends IEpisodeBase> {
+    container?(): Promise<EpisodeContainer<TEpisode>>;
+
+    /**
+     * Yields batches of episodes, to support paginated implementations
+     */
+    episodesInSeason?(season: number): AsyncIterable<TEpisode[]>;
+}
+
+export class EpisodeResolver<TEpisode extends IEpisodeBase> {
+    constructor(
+        private capabilities: IEpisodeCapabilities<TEpisode>,
+    ) {}
+
+    public async query(query: IEpisodeQuery) {
+        if (this.capabilities.container) {
+            const container = await this.capabilities.container();
+            return container.get(query);
+        }
+
+        if (
+            query.seasonIndex !== undefined
+            && this.capabilities.episodesInSeason
+        ) {
+            const batches = this.capabilities.episodesInSeason(query.seasonIndex);
+            let offset = 0;
+            for await (const batch of batches) {
+                if (query.episodeIndex - offset < batch.length) {
+                    return batch[query.episodeIndex - offset];
+                }
+                offset += batch.length;
+            }
+
+            // no such episode in this season
+            return;
+        }
+    }
+}


### PR DESCRIPTION
Currently we only support querying by season and episode number, but I could see expanding support to querying by episode title, for example.

Included are two new methods:
- `findEpisodeFor`: this expects a `IQueryResult` from eg `queryByTitle` and an `IEpisodeQuery`. This is probably the most typical use, where you might find the best-matching series from a query and then look to play an episode from there. 
- `queryEpisodeByTitle`: this is a bit wacky—and I almost removed it—but I think it could have a use: for example, you want to watch a specific episode of a show, and don't care that it's provided by a service that has ads, if your normally-preferred service doesn't have the episode in question, for example. Most channel implementations will not need to implement this method unless they have a means of performing the search in an especially optimized way—we provide a default implementation based on `findEpisodeFor` that should generally suffice.