### PR TITLE
Add the "cc" command namespace with debug helpers

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -18,7 +18,7 @@ import { login as youtubeLogin } from "./commands/auth/youtube";
 
 // type-safe conditional import via reference elision
 import * as AuthCommand from "./commands/auth";
-import { IAuthOpts } from "./commands/auth/config";
+import { createChromecastCommands } from "./commands/cc";
 
 let authCommandModule: typeof AuthCommand;
 
@@ -121,10 +121,7 @@ if (canAutoConfigure) {
             // chromagnon is a huge dependency, and installs don't need
             // to require it since it's just for config, so we lazily
             // import the dependency in case it's not available
-            // NOTE: yargs converts the ignore-errors flag to
-            // camelCase, but typescript doesn't know that
-            const opts = argv as unknown as IAuthOpts;
-            await authCommandModule.authenticate(opts);
+            await authCommandModule.authenticate(argv);
         },
     );
 }
@@ -145,17 +142,21 @@ parser.command(
     },
 );
 
-parser.help()
+createChromecastCommands(parser)
+    .help()
     .demandCommand(1);
 
 export async function main(args: any[]) {
     const result = await parser.parse(args.slice(2));
-    if (result.config) {
-        // we loaded config, which means yargs handled it
+    if (result.config || result._[0] === "cc") {
+        // We loaded config, which means yargs handled it,
+        // or it was a cc command, in which case... yargs
+        // handled it. Why doesn't yargs handle missing top-level
+        // commands...? No idea!
         return;
     }
 
     parser.showHelp();
-
+    console.log();
     console.log("Unknown command", result._[0]);
 }

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -144,6 +144,7 @@ parser.command(
 
 createChromecastCommands(parser)
     .help()
+    .recommendCommands()
     .demandCommand(1);
 
 export async function main(args: any[]) {

--- a/src/cli/commands/cc/index.ts
+++ b/src/cli/commands/cc/index.ts
@@ -1,15 +1,28 @@
 import yargs from "yargs";
 
+import { withConfig, withDevice } from "../../args";
+
+import receiverStatus from "./receiver-status";
+
+function useSharedArgs<T>(_args: yargs.Argv<T>): void {
+    // NOTE: We have to provide a builder; this function
+    // is a helper to avoid having to write args => args
+    // all the time
+}
+
 export function createChromecastCommands(parser: yargs.Argv) {
     return parser.command(
         "cc <subcommand>",
         "Chromecast debug commands",
-        // (args: yargs.Argv) => args,
-        (args: yargs.Argv) => args.command("check", "Get the current chromecast state", {}, () => {
-            console.log("DO check");
-        }).demandCommand(1),
-        () => {
-            console.log("HANDLE cc");
-        },
+        (args: yargs.Argv) =>
+            withDevice(withConfig(args))
+                .command(
+                    "receiver-status",
+                    "Get the current receiver status",
+                    useSharedArgs,
+                    receiverStatus,
+                )
+                .demandCommand(1),
+        () => { /* nop */ },
     );
 }

--- a/src/cli/commands/cc/index.ts
+++ b/src/cli/commands/cc/index.ts
@@ -1,0 +1,15 @@
+import yargs from "yargs";
+
+export function createChromecastCommands(parser: yargs.Argv) {
+    return parser.command(
+        "cc <subcommand>",
+        "Chromecast debug commands",
+        // (args: yargs.Argv) => args,
+        (args: yargs.Argv) => args.command("check", "Get the current chromecast state", {}, () => {
+            console.log("DO check");
+        }).demandCommand(1),
+        () => {
+            console.log("HANDLE cc");
+        },
+    );
+}

--- a/src/cli/commands/cc/receiver-status.ts
+++ b/src/cli/commands/cc/receiver-status.ts
@@ -1,0 +1,13 @@
+import { ChromecastDevice } from "stratocaster";
+import { printJson } from "../util";
+
+interface IDeviceOpts {
+    device: string;
+}
+
+export default async function receiverStatus(opts: IDeviceOpts) {
+    const device = new ChromecastDevice(opts.device);
+    const status = await device.getStatus();
+    device.close();
+    printJson(status);
+}

--- a/src/cli/commands/util.ts
+++ b/src/cli/commands/util.ts
@@ -33,3 +33,7 @@ export async function prompt(promptText: string): Promise<string> {
 export function consoleWrite(str: string) {
     console.log(str.trim());
 }
+
+export function printJson(json: unknown) {
+    console.log(JSON.stringify(json, null, 2));
+}

--- a/src/util/withDevice.ts
+++ b/src/util/withDevice.ts
@@ -1,0 +1,10 @@
+import { ChromecastDevice } from "stratocaster";
+
+export default async function withDevice<R = void>(name: string, block: (device: ChromecastDevice) => Promise<R>) {
+    const device = new ChromecastDevice(name);
+    try {
+        return await block(device);
+    } finally {
+        device.close();
+    }
+}


### PR DESCRIPTION
The goal here is to provide commands that help to debug and build babbling *using* babbling.

- Scaffold out chromecast debug commands namespace
- Add cc receiver-status command
- Provide command recommendations
