### PR TITLE
Support HBO Max; drop HBO Go

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "keywords": [
     "chromecast",
     "hulu",
-    "hbogo",
+    "hbo",
     "prime",
     "youtube"
   ],

--- a/src/apps/hbo/api.ts
+++ b/src/apps/hbo/api.ts
@@ -144,6 +144,7 @@ export class HboApi {
      */
     public async getSeriesMarkers(): Promise<{ [urn: string]: ISeriesMarker }> {
         const markersResult = await this.fetchContent(["urn:hbo:series-markers:mine"]);
+        debug("markers result=", markersResult);
         return markersResult[0].body.seriesMarkers;
     }
 
@@ -210,6 +211,7 @@ export class HboApi {
 
             yield {
                 title: result.body.titles.full as string,
+                type: result.body.contentType as "FEATURE" | "SERIES" | "SERIES_EPISODE",
                 urn,
             };
         }

--- a/src/apps/hbo/api.ts
+++ b/src/apps/hbo/api.ts
@@ -5,7 +5,7 @@ import _debug from "debug";
 import { read, Token, write } from "../../token";
 import { EpisodeContainer } from "../../util/episode-container";
 
-const debug = _debug("babbling:hbogo:api");
+const debug = _debug("babbling:hbo:api");
 
 const CONTENT_URL = "https://comet.api.hbo.com/content";
 const TOKENS_URL = "https://comet.api.hbo.com/tokens";
@@ -57,7 +57,7 @@ export interface IHboEpisode {
     title: string;
 }
 
-export class HboGoApi {
+export class HboApi {
     private refreshToken: string | undefined;
     private refreshTokenExpires = 0;
 

--- a/src/apps/hbo/channel.ts
+++ b/src/apps/hbo/channel.ts
@@ -6,20 +6,20 @@ import {
 } from "../../app";
 import { EpisodeResolver } from "../../util/episode-resolver";
 
-import type { HboGoApp, IHboGoOpts } from ".";
-import { entityTypeFromUrn, HboGoApi } from "./api";
+import type { HboApp, IHboOpts } from ".";
+import { entityTypeFromUrn, HboApi } from "./api";
 
 function urnFromUrl(url: string) {
     return url.substring(url.lastIndexOf("/") + 1);
 }
 
-export class HboGoPlayerChannel implements IPlayerChannel<HboGoApp> {
-    private api: HboGoApi;
+export class HboPlayerChannel implements IPlayerChannel<HboApp> {
+    private api: HboApi;
 
     constructor(
-        private readonly options: IHboGoOpts,
+        private readonly options: IHboOpts,
     ) {
-        this.api = new HboGoApi(this.options.token);
+        this.api = new HboApi(this.options.token);
     }
 
     public ownsUrl(url: string) {
@@ -31,7 +31,7 @@ export class HboGoPlayerChannel implements IPlayerChannel<HboGoApp> {
         try {
             switch (entityTypeFromUrn(urn)) {
                 case "series":
-                    return async (app: HboGoApp) => app.resumeSeries(urn);
+                    return async (app: HboApp) => app.resumeSeries(urn);
 
                 case "episode":
                 case "extra":
@@ -39,7 +39,7 @@ export class HboGoPlayerChannel implements IPlayerChannel<HboGoApp> {
                 case "season":
                 // TODO: it may be possible to resume specific episodes or
                 // features (movies)...
-                    return async (app: HboGoApp) => app.play(urn);
+                    return async (app: HboApp) => app.play(urn);
             }
         } catch (e) {
             throw new Error(`'${urn}' doesn't look playable`);
@@ -50,7 +50,7 @@ export class HboGoPlayerChannel implements IPlayerChannel<HboGoApp> {
         item: IQueryResult,
         query: IEpisodeQuery,
     ): Promise<IEpisodeQueryResult | undefined> {
-        if (item.appName !== "HboGoApp") {
+        if (item.appName !== "HboApp") {
             throw new Error("Given QueryResult for wrong app");
         } else if (item.url == null) {
             throw new Error(`Given query result has no URL: ${item.title}`);
@@ -67,7 +67,7 @@ export class HboGoPlayerChannel implements IPlayerChannel<HboGoApp> {
 
         const url = `https://play.hbogo.com/${episode.urn}`;
         return {
-            appName: "HboGoApp",
+            appName: "HboApp",
             playable: await this.createPlayable(url),
             seriesTitle: item.title,
             title: episode.title,
@@ -81,7 +81,7 @@ export class HboGoPlayerChannel implements IPlayerChannel<HboGoApp> {
         for await (const result of this.api.search(title)) {
             const url = `https://play.hbogo.com/${result.urn}`;
             yield {
-                appName: "HboGoApp",
+                appName: "HboApp",
                 playable: await this.createPlayable(url),
                 title: result.title,
                 url,

--- a/src/apps/hbo/channel.ts
+++ b/src/apps/hbo/channel.ts
@@ -79,6 +79,12 @@ export class HboPlayerChannel implements IPlayerChannel<HboApp> {
         title: string,
     ): AsyncIterable<IQueryResult> {
         for await (const result of this.api.search(title)) {
+            if (result.type === "SERIES_EPISODE") {
+                // Don't emit episodes; this method is for
+                // finding series and movies only
+                continue;
+            }
+
             const url = `https://play.hbogo.com/${result.urn}`;
             yield {
                 appName: "HboApp",

--- a/src/apps/hbo/config.ts
+++ b/src/apps/hbo/config.ts
@@ -13,7 +13,7 @@ export class HboConfigurable implements IConfigurable<IHboOpts> {
     public async extractConfig(
         source: IConfigSource,
     ) {
-        const stream = source.storage.readAll("https://play.hbogo.com");
+        const stream = source.storage.readAll("https://play.hbomax.com");
         for await (const { key, value } of stream) {
             if (key.includes("LoginInfo.user")) {
                 const entry = JSON.parse(value);

--- a/src/apps/hbo/config.ts
+++ b/src/apps/hbo/config.ts
@@ -1,7 +1,7 @@
 import { IConfigSource, IConfigurable } from "../../cli/model";
 import { Token } from "../../token";
 
-export interface IHboGoOpts {
+export interface IHboOpts {
     /**
      * The bearer token, as found in the Authorization header
      * for a request to `https://comet.api.hbo.com/content`
@@ -9,7 +9,7 @@ export interface IHboGoOpts {
     token: Token;
 }
 
-export class HboGoConfigurable implements IConfigurable<IHboGoOpts> {
+export class HboConfigurable implements IConfigurable<IHboOpts> {
     public async extractConfig(
         source: IConfigSource,
     ) {

--- a/src/apps/hbo/index.ts
+++ b/src/apps/hbo/index.ts
@@ -13,7 +13,7 @@ import { HboConfigurable, IHboOpts } from "./config";
 const debug = _debug("babbling:hbo");
 export { IHboOpts } from "./config";
 
-const APP_ID = "144BDEF0";
+const APP_ID = "DD4BFB02";
 const HBO_GO_NS = "urn:x-cast:hbogo";
 
 export interface IHboPlayOptions {

--- a/src/apps/hbo/index.ts
+++ b/src/apps/hbo/index.ts
@@ -66,7 +66,6 @@ export class HboApp extends BaseApp {
 
         debug("Joined media session", s.destination);
 
-        // const hbogo = await this.joinOrRunNamespace(HBO_GO_NS);
         const req: ILoadRequest = {
             autoplay: true,
             customData: {

--- a/src/apps/hbo/index.ts
+++ b/src/apps/hbo/index.ts
@@ -3,7 +3,6 @@ import _debug from "debug";
 import { ChromecastDevice } from "stratocaster";
 
 import { BaseApp, MEDIA_NS } from "../base";
-import { awaitMessageOfType } from "../util";
 import { ILoadRequest } from "../../cast";
 
 import { HboApi } from "./api";
@@ -14,7 +13,6 @@ const debug = _debug("babbling:hbo");
 export { IHboOpts } from "./config";
 
 const APP_ID = "DD4BFB02";
-const HBO_GO_NS = "urn:x-cast:hbogo";
 
 export interface IHboPlayOptions {
     /** Eg "ENG" */
@@ -68,7 +66,7 @@ export class HboApp extends BaseApp {
 
         debug("Joined media session", s.destination);
 
-        const hbogo = await this.joinOrRunNamespace(HBO_GO_NS);
+        // const hbogo = await this.joinOrRunNamespace(HBO_GO_NS);
         const req: ILoadRequest = {
             autoplay: true,
             customData: {
@@ -110,14 +108,8 @@ export class HboApp extends BaseApp {
         const ms = await s.send(req as any);
         debug(ms);
 
-        let ps;
-        do {
-            ps = await awaitMessageOfType(hbogo, "PLAYERSTATE");
-            debug(ps);
-        } while (!ps.success);
-
-        if (ps.playerState === "APPLICATION_ERROR") {
-            throw new Error("Error");
+        if (ms.type !== "MEDIA_STATUS") {
+            throw new Error(`Load failed: ${ms}`);
         }
 
         debug("Done!");

--- a/src/apps/hbo/index.ts
+++ b/src/apps/hbo/index.ts
@@ -6,17 +6,17 @@ import { BaseApp, MEDIA_NS } from "../base";
 import { awaitMessageOfType } from "../util";
 import { ILoadRequest } from "../../cast";
 
-import { HboGoApi } from "./api";
-import { HboGoPlayerChannel } from "./channel";
-import { HboGoConfigurable, IHboGoOpts } from "./config";
+import { HboApi } from "./api";
+import { HboPlayerChannel } from "./channel";
+import { HboConfigurable, IHboOpts } from "./config";
 
-const debug = _debug("babbling:hbogo");
-export { IHboGoOpts } from "./config";
+const debug = _debug("babbling:hbo");
+export { IHboOpts } from "./config";
 
 const APP_ID = "144BDEF0";
 const HBO_GO_NS = "urn:x-cast:hbogo";
 
-export interface IHboGoPlayOptions {
+export interface IHboPlayOptions {
     /** Eg "ENG" */
     language?: string;
     showSubtitles?: boolean;
@@ -27,22 +27,22 @@ export interface IHboGoPlayOptions {
     startTime?: number;
 }
 
-export class HboGoApp extends BaseApp {
+export class HboApp extends BaseApp {
     public static tokenConfigKeys = ["token"];
-    public static configurable = new HboGoConfigurable();
-    public static createPlayerChannel(options: IHboGoOpts) {
-        return new HboGoPlayerChannel(options);
+    public static configurable = new HboConfigurable();
+    public static createPlayerChannel(options: IHboOpts) {
+        return new HboPlayerChannel(options);
     }
 
-    private readonly api: HboGoApi;
+    private readonly api: HboApi;
 
-    constructor(device: ChromecastDevice, options: IHboGoOpts) {
+    constructor(device: ChromecastDevice, options: IHboOpts) {
         super(device, {
             appId: APP_ID,
             sessionNs: MEDIA_NS,
         });
 
-        this.api = new HboGoApi(options.token);
+        this.api = new HboApi(options.token);
     }
 
     /**
@@ -51,7 +51,7 @@ export class HboGoApp extends BaseApp {
      */
     public async play(
         urn: string,
-        options: IHboGoPlayOptions = {},
+        options: IHboPlayOptions = {},
     ) {
         const {
             deviceId,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 export { ChromecastDevice } from "./device";
 export { PlayerBuilder } from "./player";
 export { DisneyApp, IDisneyOpts } from "./apps/disney";
-export { HboGoApp, IHboGoOpts, IHboGoPlayOptions } from "./apps/hbogo";
+export { HboApp, IHboOpts, IHboPlayOptions } from "./apps/hbo";
 export { HuluApp, IHuluOpts } from "./apps/hulu";
 export { PrimeApp, IPrimeOpts } from "./apps/prime";
 export { YoutubeApp, IYoutubeOpts } from "./apps/youtube";


### PR DESCRIPTION
Happily, the underlying protocol is basically identical, so there weren't many changes needed to get this working!

- Rename hbogo -> hbo
- Update the app ID
- Update the Configurable for Hbo
- Filter out episodes from HBO search results
- Clean up error waiting for PLAYERSTATUS message
