### PR TITLE
Fix searches for HBO Provider

### DIFF
--- a/src/apps/hbo/api.ts
+++ b/src/apps/hbo/api.ts
@@ -225,7 +225,7 @@ export class HboApi {
     }
 
     public async* search(title: string) {
-        const searchUrn = `urn:hbo:search:${encodeURIComponent(title)}`;
+        const searchUrn = `urn:hbo:flexisearch:${encodeURIComponent(title)}`;
         const content = await this.fetchContent([searchUrn]);
 
         // NOTE: the first one just has references to the ids of

--- a/src/apps/hbo/channel.ts
+++ b/src/apps/hbo/channel.ts
@@ -99,7 +99,12 @@ export class HboPlayerChannel implements IPlayerChannel<HboApp> {
                 continue;
             }
 
-            const url = `https://play.hbomax.com/${result.urn}`;
+            // HBO Max may use a slightly different URN structure for the
+            // series / movie page than it emits in the search result
+            const urn = unpackUrn(result.urn);
+            const url = urn.pageType != null
+                ? `https://play.hbomax.com/${result.urn}`
+                : `https://play.hbomax.com/page/urn:hbo:page:${urn.id}:type:${urn.type}`;
             yield {
                 appName: "HboApp",
                 playable: await this.createPlayable(url),


### PR DESCRIPTION
- Update search URN to fix HBO searches
- Emit "page" URIs for HBO search results so they load in a browser
