### PR TITLE
Update HBO to support latest protocol changes

### DIFF
--- a/src/apps/hbo/channel.ts
+++ b/src/apps/hbo/channel.ts
@@ -1,3 +1,5 @@
+import createDebug from "debug";
+
 import {
     IEpisodeQuery,
     IEpisodeQueryResult,
@@ -8,6 +10,8 @@ import { EpisodeResolver } from "../../util/episode-resolver";
 
 import type { HboApp, IHboOpts } from ".";
 import { entityTypeFromUrn, HboApi, unpackUrn } from "./api";
+
+const debug = createDebug("babbling:hbo:channel");
 
 function normalizeUrn(urn: string) {
     const unpacked = unpackUrn(urn);
@@ -45,7 +49,10 @@ export class HboPlayerChannel implements IPlayerChannel<HboApp> {
         try {
             switch (entityTypeFromUrn(urn)) {
                 case "series":
-                    return async (app: HboApp) => app.resumeSeries(urn);
+                    return async (app: HboApp) => {
+                        debug("Resume series @", url);
+                        return app.resumeSeries(urn);
+                    };
 
                 case "episode":
                 case "extra":

--- a/src/apps/hbo/index.ts
+++ b/src/apps/hbo/index.ts
@@ -108,7 +108,8 @@ export class HboApp extends BaseApp {
         debug(ms);
 
         if (ms.type !== "MEDIA_STATUS") {
-            throw new Error(`Load failed: ${ms}`);
+            const message = (ms as any).customData?.exception?.message ?? JSON.stringify(ms);
+            throw new Error(`Load of ${urn} failed: ${message}`);
         }
 
         debug("Done!");


### PR DESCRIPTION
HBO has apparently updated their chromecast integration to no longer use the standard messages, which is very lame. This PR updates our support for their new wacky version.

It was mostly figured out through experimentation with the web app, placing breakpoints and seeing what that client was trying to send.
