### PR TITLE
Add support for HBO "franchise" types

### DIFF
--- a/src/apps/hbo/channel.ts
+++ b/src/apps/hbo/channel.ts
@@ -66,6 +66,14 @@ export class HboPlayerChannel implements IPlayerChannel<HboApp> {
 
         try {
             switch (entityTypeFromUrn(urn)) {
+                case "franchise":
+                    // Is this always correct?
+                    const seriesUrn = await this.api.resolveFranchiseSeries(urn);
+                    return async (app: HboApp) => {
+                        debug("Resume franchise series @", url);
+                        return app.resumeSeries(seriesUrn);
+                    };
+
                 case "series":
                     return async (app: HboApp) => {
                         debug("Resume series @", url);
@@ -76,6 +84,7 @@ export class HboPlayerChannel implements IPlayerChannel<HboApp> {
                 case "extra":
                 case "feature":
                 case "season":
+                default:
                 // TODO: it may be possible to resume specific episodes or
                 // features (movies)...
                     return async (app: HboApp) => app.play(urn);

--- a/src/apps/hbo/index.ts
+++ b/src/apps/hbo/index.ts
@@ -120,11 +120,11 @@ export class HboApp extends BaseApp {
             const status = m.data.status[0];
             debug("Received:", status);
 
-            if (status.media.contentId !== urn && status.media.entity !== urn && status.playerState === "IDLE") {
+            if (status.media?.contentId !== urn && status.media?.entity !== urn && status.playerState === "IDLE") {
                 throw new Error(`Failed to play ${urn}`);
             }
 
-            if (status.media.contentId !== "" && status.media.contentId !== urn) {
+            if (status.media?.contentId !== "" && status.media?.contentId !== urn) {
                 // Something else must be playing
                 debug("Got MEDIA_STATUS for", status.media);
                 return;


### PR DESCRIPTION
For example, Last Week Tonight with John Oliver is returned as a
"franchise" which *contains* the series we can then watch. There may be
other franchise types that work differently; this should work for now,
but I suspect we may need to dig deeper in the future....
