### PR TITLE
Update public Player API to improve usability

### DIFF
--- a/src/cli/commands/recommend.ts
+++ b/src/cli/commands/recommend.ts
@@ -1,4 +1,3 @@
-import { ChromecastDevice } from "../../device";
 import { PlayerBuilder } from "../../player";
 
 import { formatQueryResults } from "./search";
@@ -11,8 +10,7 @@ export default async function getRecommendations(
     opts: IGetRecommendationsOpts,
 ) {
     const builder = await PlayerBuilder.autoInflate(opts.config);
-    builder.addDevice(new ChromecastDevice("_unused_"));
-    const player = builder.build();
+    const player = builder.buildQueryOnly();
 
     await formatQueryResults(player.queryRecommended());
 }

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -3,7 +3,6 @@
 import createDebug from "debug";
 
 import { IQueryResult } from "../../app";
-import { ChromecastDevice } from "../../device";
 import { PlayerBuilder } from "../../player";
 import { consoleWrite } from "./util";
 
@@ -53,8 +52,7 @@ export async function formatQueryResults(results: AsyncIterable<IQueryResult>) {
 
 export default async function searchByTitle(opts: ISearchByTitleOpts) {
     const builder = await PlayerBuilder.autoInflate(opts.config);
-    builder.addDevice(new ChromecastDevice("_unused_"));
-    const player = builder.build();
+    const player = builder.buildQueryOnly();
 
     const results = player.queryByTitle(opts.title, (app, e) => {
         debug("Encountered error searching", app, e);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { ChromecastDevice } from "./device";
 export { PlayerBuilder } from "./player";
+export type { Player, QueryOnlyPlayer } from "./player";
 export { DisneyApp, IDisneyOpts } from "./apps/disney";
 export { HboApp, IHboOpts, IHboPlayOptions } from "./apps/hbo";
 export { HuluApp, IHuluOpts } from "./apps/hulu";

--- a/src/player.ts
+++ b/src/player.ts
@@ -85,7 +85,9 @@ export class Player {
         // constructed in this file and, in general, should only be constructed
         // via PlayerBuilder anyway
         // eslint-disable-next-line @typescript-eslint/no-use-before-define
-        return new PlayerBuilder(this.apps, this.devices, this.opts);
+        return new PlayerBuilder([...this.apps], [...this.devices], {
+            ...this.opts,
+        });
     }
 
     public async playUrl(url: string, opts: IPlayableOptions = {}) {
@@ -361,6 +363,6 @@ export class PlayerBuilder {
             throw new Error("You must have at least one app enabled");
         }
 
-        return new Player(this.apps, this.devices, this.opts);
+        return new Player([...this.apps], [...this.devices], { ...this.opts });
     }
 }

--- a/src/player.ts
+++ b/src/player.ts
@@ -81,13 +81,13 @@ export class Player {
     ) {}
 
     public buildUpon() {
+        // NOTE: We create and clone a PlayerBuilder to ensure that mutations of
+        // the resulting Builder do not also mutate this object.
         // NOTE: It should be safe to use this here; Player will not be
         // constructed in this file and, in general, should only be constructed
         // via PlayerBuilder anyway
         // eslint-disable-next-line @typescript-eslint/no-use-before-define
-        return new PlayerBuilder([...this.apps], [...this.devices], {
-            ...this.opts,
-        });
+        return new PlayerBuilder(this.apps, this.devices, this.opts).clone();
     }
 
     public async playUrl(url: string, opts: IPlayableOptions = {}) {
@@ -341,6 +341,15 @@ export class PlayerBuilder {
     public configure(opts: IPlayerOpts) {
         this.opts = opts;
         return this;
+    }
+
+    /**
+     * Create a new PlayerBuilder instance with the same initial config as this PlayerBuilder
+     */
+    public clone() {
+        return new PlayerBuilder([...this.apps], [...this.devices], {
+            ...this.opts,
+        });
     }
 
     /**


### PR DESCRIPTION
In particular:

- All calls to `PlayerBuilder.build()` now return distinct Player instances; previously, the array of apps/devices were shared across all instances created by a single `PlayerBuilder`. This is unexpected and bizarre behavior that no longer occurs.
- The `Player` type is now properly exported for use in client code
- `PlayerBuilder.buildQueryOnly()` can be used to ignore the requirement that Player instances must have at least one target Device attached, for when you don't care about playback.
- `Player.buildUpon()` and `PlayerBuilder.clone()` methods can be used to simplify factory use cases, where eg configured apps will be shared across `Player` instances, but the target devices will change per request.
