### PR TITLE
Implement API to distinguish recommended from recent

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -85,6 +85,38 @@ export interface IQueryResult {
     isPreferred?: boolean;
 }
 
+export enum RecommendationType {
+    // This item was recently watched
+    Recent = "recent",
+
+    // This item was saved by the user. Sometimes called "queue" or "watch list"
+    Saved = "saved",
+
+    // This item was newly added
+    New = "new",
+
+    // This item is "popular," but not necessarily an interest-based recommendation
+    Popular = "popular",
+
+    // This item was recommended due to perceived similarity to titles or
+    // genres the user has enjoyed.
+    Interest = "interest",
+
+    // This item was a curated recommendation
+    Curated = "curated",
+}
+
+export interface IRecommendation extends IQueryResult {
+    recommendationType: RecommendationType;
+    recommendationCategoryKey?: string;
+    recommendationCategoryTitle?: string;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface IRecommendationQuery {
+    // TODO
+}
+
 export interface IEpisodeQueryResult extends IQueryResult {
     seriesTitle: string;
 }
@@ -147,8 +179,24 @@ export interface IPlayerChannel<TSelf extends IApp> {
     /**
      * Search for {@see Player.play}'able media per the source
      * apps' recommendations.
+     * @deprecated Most channels implemented this as `queryRecent`, so the naming
+     * is unhelpful. Use `queryRecent` or `queryRecommendations` instead.
      */
     queryRecommended?(): AsyncIterable<IQueryResult>;
+
+    /**
+     * Search for {@see Player.play}'able media per the source apps'
+     * recommendations. If no `query` is provided (or if the provider doesn't
+     * support `query` filtering) some default set of recommendation types will be
+     * selected.
+     *
+     * NOTE: This method is not currently stable; its behavior may change
+     * slightly in point releases, and though changes *should* be non-breaking,
+     * they may be unexpected.
+     */
+    queryRecommendations?(
+        query?: IRecommendationQuery,
+    ): AsyncIterable<IRecommendation>;
 
     /**
      * Search for {@see Player.play}'able media per the source

--- a/src/app.ts
+++ b/src/app.ts
@@ -146,10 +146,15 @@ export interface IPlayerChannel<TSelf extends IApp> {
 
     /**
      * Search for {@see Player.play}'able media per the source
-     * apps' recommendations. Could be (but not necessarily)
-     * based on recency
+     * apps' recommendations.
      */
     queryRecommended?(): AsyncIterable<IQueryResult>;
+
+    /**
+     * Search for {@see Player.play}'able media per the source
+     * apps' recently viewed media.
+     */
+    queryRecent?(): AsyncIterable<IQueryResult>;
 }
 
 export interface IPlayerEnabledConstructor<

--- a/src/app.ts
+++ b/src/app.ts
@@ -114,7 +114,7 @@ export interface IRecommendation extends IQueryResult {
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface IRecommendationQuery {
-    // TODO
+    excludeTypes?: RecommendationType[];
 }
 
 export interface IEpisodeQueryResult extends IQueryResult {
@@ -191,8 +191,9 @@ export interface IPlayerChannel<TSelf extends IApp> {
      * selected.
      *
      * NOTE: This method is not currently stable; its behavior may change
-     * slightly in point releases, and though changes *should* be non-breaking,
-     * they may be unexpected.
+     * slightly in point releases, and `IRecommendationQuery` may also change.
+     * Requests for the "default" behavior (IE: without any `query` provided)
+     * are unlikely to break, but no specific "default" behavior is guaranteed.
      */
     queryRecommendations?(
         query?: IRecommendationQuery,

--- a/src/apps/disney/channel.ts
+++ b/src/apps/disney/channel.ts
@@ -6,6 +6,7 @@ import {
     IPlayableOptions,
     IPlayerChannel,
     IQueryResult,
+    IRecommendationQuery,
     RecommendationType,
 } from "../../app";
 import { mergeAsyncIterables } from "../../async";
@@ -14,6 +15,7 @@ import { mergeAsyncIterables } from "../../async";
 // importing it for the type definition
 import type { DisneyApp, IDisneyOpts } from ".";
 import { DisneyApi, ICollection, ISearchHit } from "./api";
+import filterRecommendations from "../../util/filterRecommendations";
 
 const debug = _debug("babbling:DisneyApp:channel");
 
@@ -118,8 +120,11 @@ export class DisneyPlayerChannel implements IPlayerChannel<DisneyApp> {
         yield* this.queryCollectionType(RECOMMENDATION_SET_TYPES);
     }
 
-    public async *queryRecommendations() {
-        yield* this.queryCollectionType(RECOMMENDATION_SET_TYPES);
+    public async *queryRecommendations(query?: IRecommendationQuery) {
+        yield* filterRecommendations(
+            query,
+            this.queryCollectionType(RECOMMENDATION_SET_TYPES),
+        );
     }
 
     private async *queryCollectionType(types: Set<CollectionSetType>) {

--- a/src/apps/disney/channel.ts
+++ b/src/apps/disney/channel.ts
@@ -20,10 +20,7 @@ const PLAYBACK_URL = "https://www.disneyplus.com/video/";
 const SERIES_URL = "https://www.disneyplus.com/series/";
 const MOVIE_URL = "https://www.disneyplus.com/movies/";
 
-const RECOMMENDATION_SET_TYPES = new Set([
-    "RecommendationSet",
-    "ContinueWatchingSet",
-]);
+type CollectionSetType = "RecommendationSet" | "ContinueWatchingSet";
 
 function getSeriesIdFromUrl(url: string) {
     const m = url.match(/\/series\/[^/]+\/(.+)$/);
@@ -107,11 +104,17 @@ export class DisneyPlayerChannel implements IPlayerChannel<DisneyApp> {
         }
     }
 
+    public async *queryRecent() {
+        yield* this.queryCollectionType("ContinueWatchingSet");
+    }
+
     public async *queryRecommended() {
+        yield* this.queryCollectionType("RecommendationSet");
+    }
+
+    private async *queryCollectionType(type: CollectionSetType) {
         const collections = await this.api.getCollections();
-        const toFetch = collections.filter((coll) =>
-            RECOMMENDATION_SET_TYPES.has(coll.type),
-        );
+        const toFetch = collections.filter((coll) => coll.type === type);
 
         yield* mergeAsyncIterables(
             toFetch.map((coll) => this.collectionIterable(coll)),

--- a/src/apps/disney/channel.ts
+++ b/src/apps/disney/channel.ts
@@ -138,10 +138,15 @@ export class DisneyPlayerChannel implements IPlayerChannel<DisneyApp> {
 
     private async *collectionIterable(coll: ICollection) {
         const items = await this.api.loadCollection(coll);
+        const info = this.collectionTypeToRecommendationInfo(coll.type);
+
         for (const item of items) {
             const result = this.searchHitToQueryResult(item);
             if (result) {
-                yield { ...result, recommendationType: RecommendationType.New };
+                yield {
+                    ...result,
+                    ...info,
+                };
             }
         }
     }

--- a/src/apps/disney/channel.ts
+++ b/src/apps/disney/channel.ts
@@ -160,7 +160,7 @@ export class DisneyPlayerChannel implements IPlayerChannel<DisneyApp> {
                 return { recommendationType: RecommendationType.Recent };
 
             case "CuratedSet":
-                return { RecommendationType: RecommendationType.Curated };
+                return { recommendationType: RecommendationType.Curated };
 
             case "RecommendationSet": // ?
                 return { recommendationType: RecommendationType.Popular };

--- a/src/apps/hbo/channel.ts
+++ b/src/apps/hbo/channel.ts
@@ -5,6 +5,7 @@ import {
     IEpisodeQueryResult,
     IPlayerChannel,
     IQueryResult,
+    IRecommendationQuery,
     RecommendationType,
 } from "../../app";
 import { EpisodeResolver } from "../../util/episode-resolver";
@@ -12,6 +13,7 @@ import { EpisodeResolver } from "../../util/episode-resolver";
 import type { HboApp, IHboOpts } from ".";
 import { entityTypeFromUrn, HboApi, IHboResult, unpackUrn } from "./api";
 import withRecommendationType from "../../util/withRecommendationType";
+import filterRecommendations from "../../util/filterRecommendations";
 
 const debug = createDebug("babbling:hbo:channel");
 
@@ -141,10 +143,13 @@ export class HboPlayerChannel implements IPlayerChannel<HboApp> {
         yield* this.yieldPlayables(this.api.queryContinueWatching());
     }
 
-    public async *queryRecommendations() {
-        yield* withRecommendationType(
-            this.yieldPlayables(this.api.queryRecommended()),
-            RecommendationType.Interest,
+    public async *queryRecommendations(query?: IRecommendationQuery) {
+        yield* filterRecommendations(
+            query,
+            withRecommendationType(
+                RecommendationType.Interest,
+                this.yieldPlayables(this.api.queryRecommended()),
+            ),
         );
     }
 

--- a/src/apps/hbo/channel.ts
+++ b/src/apps/hbo/channel.ts
@@ -135,11 +135,12 @@ export class HboPlayerChannel implements IPlayerChannel<HboApp> {
         }
     }
 
-    public async *queryRecommended() {
-        // NOTE: HBO actually has a "recommended," but the other apps are returning
-        // "continue watching" content here, so until we update the API to have that
-        // as a distinct method, let's stay internally consistent
+    public async *queryRecent() {
         yield* this.yieldPlayables(this.api.queryContinueWatching());
+    }
+
+    public async *queryRecommended() {
+        yield* this.yieldPlayables(this.api.queryRecommended());
     }
 
     private async *yieldPlayables(source: ReturnType<typeof this.api.search>) {

--- a/src/apps/hbo/channel.ts
+++ b/src/apps/hbo/channel.ts
@@ -5,11 +5,13 @@ import {
     IEpisodeQueryResult,
     IPlayerChannel,
     IQueryResult,
+    RecommendationType,
 } from "../../app";
 import { EpisodeResolver } from "../../util/episode-resolver";
 
 import type { HboApp, IHboOpts } from ".";
 import { entityTypeFromUrn, HboApi, IHboResult, unpackUrn } from "./api";
+import withRecommendationType from "../../util/withRecommendationType";
 
 const debug = createDebug("babbling:hbo:channel");
 
@@ -139,8 +141,16 @@ export class HboPlayerChannel implements IPlayerChannel<HboApp> {
         yield* this.yieldPlayables(this.api.queryContinueWatching());
     }
 
+    public async *queryRecommendations() {
+        yield* withRecommendationType(
+            this.yieldPlayables(this.api.queryRecommended()),
+            RecommendationType.Interest,
+        );
+    }
+
     public async *queryRecommended() {
-        yield* this.yieldPlayables(this.api.queryRecommended());
+        // NOTE: Legacy behavior:
+        yield* this.queryRecent();
     }
 
     private async *yieldPlayables(source: ReturnType<typeof this.api.search>) {

--- a/src/apps/hulu/channel.ts
+++ b/src/apps/hulu/channel.ts
@@ -124,7 +124,7 @@ export class HuluPlayerChannel implements IPlayerChannel<HuluApp> {
         }
     }
 
-    public async *queryRecommended() {
+    public async *queryRecent() {
         const results = new HuluApi(this.options).fetchRecent();
         for await (const item of results) {
             const { id } = item;
@@ -150,5 +150,9 @@ export class HuluPlayerChannel implements IPlayerChannel<HuluApp> {
                 },
             };
         }
+    }
+
+    public async *queryRecommended() {
+        yield* this.queryRecent();
     }
 }

--- a/src/apps/hulu/channel.ts
+++ b/src/apps/hulu/channel.ts
@@ -5,12 +5,14 @@ import {
     IEpisodeQueryResult,
     IPlayerChannel,
     IQueryResult,
+    IRecommendationQuery,
     RecommendationType,
 } from "../../app";
 
 import type { HuluApp, IHuluOpts } from ".";
 import { HuluApi, supportedEntityTypes } from "./api";
 import withRecommendationType from "../../util/withRecommendationType";
+import filterRecommendations from "../../util/filterRecommendations";
 
 const debug = _debug("babbling:hulu:channel");
 
@@ -159,10 +161,13 @@ export class HuluPlayerChannel implements IPlayerChannel<HuluApp> {
         yield* this.queryRecent();
     }
 
-    public async *queryRecommendations() {
-        yield* withRecommendationType(
-            this.queryRecent(),
-            RecommendationType.Recent,
+    public async *queryRecommendations(query?: IRecommendationQuery) {
+        yield* filterRecommendations(
+            query,
+            withRecommendationType(
+                RecommendationType.Recent,
+                this.queryRecent(),
+            ),
         );
     }
 }

--- a/src/apps/hulu/channel.ts
+++ b/src/apps/hulu/channel.ts
@@ -5,10 +5,12 @@ import {
     IEpisodeQueryResult,
     IPlayerChannel,
     IQueryResult,
+    RecommendationType,
 } from "../../app";
 
 import type { HuluApp, IHuluOpts } from ".";
 import { HuluApi, supportedEntityTypes } from "./api";
+import withRecommendationType from "../../util/withRecommendationType";
 
 const debug = _debug("babbling:hulu:channel");
 
@@ -153,6 +155,14 @@ export class HuluPlayerChannel implements IPlayerChannel<HuluApp> {
     }
 
     public async *queryRecommended() {
+        // NOTE: legacy behavior
         yield* this.queryRecent();
+    }
+
+    public async *queryRecommendations() {
+        yield* withRecommendationType(
+            this.queryRecent(),
+            RecommendationType.Recent,
+        );
     }
 }

--- a/src/apps/plex/channel.ts
+++ b/src/apps/plex/channel.ts
@@ -32,11 +32,15 @@ export class PlexPlayerChannel implements IPlayerChannel<PlexApp> {
         };
     }
 
-    public async *queryRecommended() {
+    public async *queryRecent() {
         const items = await this.api.getContinueWatching();
         for (const item of items) {
             yield await this.itemToQueryResult(item);
         }
+    }
+
+    public async *queryRecommended() {
+        yield* this.queryRecent();
     }
 
     public async *queryByTitle(title: string): AsyncIterable<IQueryResult> {

--- a/src/apps/plex/channel.ts
+++ b/src/apps/plex/channel.ts
@@ -33,10 +33,7 @@ export class PlexPlayerChannel implements IPlayerChannel<PlexApp> {
     }
 
     public async *queryRecent() {
-        const items = await this.api.getContinueWatching();
-        for (const item of items) {
-            yield await this.itemToQueryResult(item);
-        }
+        yield* this.yieldQueryResults(this.api.getContinueWatching());
     }
 
     public async *queryRecommended() {
@@ -44,7 +41,11 @@ export class PlexPlayerChannel implements IPlayerChannel<PlexApp> {
     }
 
     public async *queryByTitle(title: string): AsyncIterable<IQueryResult> {
-        for (const item of await this.api.search(title)) {
+        yield* this.yieldQueryResults(this.api.search(title));
+    }
+
+    private async *yieldQueryResults(items: Promise<IPlexItem[]>) {
+        for (const item of await items) {
             yield await this.itemToQueryResult(item);
         }
     }

--- a/src/apps/plex/channel.ts
+++ b/src/apps/plex/channel.ts
@@ -1,7 +1,13 @@
 import createDebug from "debug";
 
 import { PlexApp } from ".";
-import { IPlayableOptions, IPlayerChannel, IQueryResult } from "../../app";
+import {
+    IPlayableOptions,
+    IPlayerChannel,
+    IQueryResult,
+    RecommendationType,
+} from "../../app";
+import withRecommendationType from "../../util/withRecommendationType";
 import { PlexApi } from "./api";
 import { IPlexOpts } from "./config";
 import { IPlexItem } from "./model";
@@ -37,7 +43,15 @@ export class PlexPlayerChannel implements IPlayerChannel<PlexApp> {
     }
 
     public async *queryRecommended() {
+        // NOTE: Legacy behavior:
         yield* this.queryRecent();
+    }
+
+    public async *queryRecommendations() {
+        yield* withRecommendationType(
+            this.queryRecent(),
+            RecommendationType.Recent,
+        );
     }
 
     public async *queryByTitle(title: string): AsyncIterable<IQueryResult> {

--- a/src/apps/plex/channel.ts
+++ b/src/apps/plex/channel.ts
@@ -5,8 +5,10 @@ import {
     IPlayableOptions,
     IPlayerChannel,
     IQueryResult,
+    IRecommendationQuery,
     RecommendationType,
 } from "../../app";
+import filterRecommendations from "../../util/filterRecommendations";
 import withRecommendationType from "../../util/withRecommendationType";
 import { PlexApi } from "./api";
 import { IPlexOpts } from "./config";
@@ -47,10 +49,13 @@ export class PlexPlayerChannel implements IPlayerChannel<PlexApp> {
         yield* this.queryRecent();
     }
 
-    public async *queryRecommendations() {
-        yield* withRecommendationType(
-            this.queryRecent(),
-            RecommendationType.Recent,
+    public async *queryRecommendations(query?: IRecommendationQuery) {
+        yield* filterRecommendations(
+            query,
+            withRecommendationType(
+                RecommendationType.Recent,
+                this.queryRecent(),
+            ),
         );
     }
 

--- a/src/apps/prime/channel.ts
+++ b/src/apps/prime/channel.ts
@@ -8,6 +8,7 @@ import {
     IPlayableOptions,
     IPlayerChannel,
     IQueryResult,
+    IRecommendationQuery,
     RecommendationType,
 } from "../../app";
 import { EpisodeResolver } from "../../util/episode-resolver";
@@ -20,6 +21,7 @@ import { PrimeApi } from "./api";
 import { PrimeEpisodeCapabilities } from "./api/episode-capabilities";
 import { AvailabilityType, IAvailability, ISearchResult } from "./model";
 import withRecommendationType from "../../util/withRecommendationType";
+import filterRecommendations from "../../util/filterRecommendations";
 
 const debug = _debug("babbling:PrimeApp:player");
 
@@ -210,10 +212,13 @@ export class PrimePlayerChannel implements IPlayerChannel<PrimeApp> {
         yield* this.queryRecent();
     }
 
-    public async *queryRecommendations() {
-        yield* withRecommendationType(
-            this.queryRecent(),
-            RecommendationType.Recent,
+    public async *queryRecommendations(query?: IRecommendationQuery) {
+        yield* filterRecommendations(
+            query,
+            withRecommendationType(
+                RecommendationType.Recent,
+                this.queryRecent(),
+            ),
         );
     }
 

--- a/src/apps/prime/channel.ts
+++ b/src/apps/prime/channel.ts
@@ -8,6 +8,7 @@ import {
     IPlayableOptions,
     IPlayerChannel,
     IQueryResult,
+    RecommendationType,
 } from "../../app";
 import { EpisodeResolver } from "../../util/episode-resolver";
 
@@ -18,6 +19,7 @@ import type { IPrimeOpts, PrimeApp } from ".";
 import { PrimeApi } from "./api";
 import { PrimeEpisodeCapabilities } from "./api/episode-capabilities";
 import { AvailabilityType, IAvailability, ISearchResult } from "./model";
+import withRecommendationType from "../../util/withRecommendationType";
 
 const debug = _debug("babbling:PrimeApp:player");
 
@@ -204,7 +206,15 @@ export class PrimePlayerChannel implements IPlayerChannel<PrimeApp> {
     public async *queryRecommended(): AsyncIterable<
         IQueryResult & { titleId: string }
     > {
+        // NOTE: Legacy behavior:
         yield* this.queryRecent();
+    }
+
+    public async *queryRecommendations() {
+        yield* withRecommendationType(
+            this.queryRecent(),
+            RecommendationType.Recent,
+        );
     }
 
     public urlFor(item: { titleId: string }) {

--- a/src/apps/prime/channel.ts
+++ b/src/apps/prime/channel.ts
@@ -184,7 +184,7 @@ export class PrimePlayerChannel implements IPlayerChannel<PrimeApp> {
         }
     }
 
-    public async *queryRecommended(): AsyncIterable<
+    public async *queryRecent(): AsyncIterable<
         IQueryResult & { titleId: string }
     > {
         const api = new PrimeApi(this.options);
@@ -199,6 +199,12 @@ export class PrimePlayerChannel implements IPlayerChannel<PrimeApp> {
                 url: this.urlFor(result),
             };
         }
+    }
+
+    public async *queryRecommended(): AsyncIterable<
+        IQueryResult & { titleId: string }
+    > {
+        yield* this.queryRecent();
     }
 
     public urlFor(item: { titleId: string }) {

--- a/src/util/filterRecommendations.ts
+++ b/src/util/filterRecommendations.ts
@@ -1,0 +1,24 @@
+import type { IRecommendation, IRecommendationQuery } from "../app";
+
+export function recommendationQueryMatches(
+    query: IRecommendationQuery | undefined,
+    _item: IRecommendation,
+) {
+    if (query == null) {
+        return true;
+    }
+
+    // TODO: Handle query params
+    return true;
+}
+
+export default async function* filterRecommendations<T extends IRecommendation>(
+    query: IRecommendationQuery | undefined,
+    items: AsyncIterable<T>,
+) {
+    for await (const item of items) {
+        if (recommendationQueryMatches(query, item)) {
+            yield item;
+        }
+    }
+}

--- a/src/util/filterRecommendations.ts
+++ b/src/util/filterRecommendations.ts
@@ -1,23 +1,34 @@
 import type { IRecommendation, IRecommendationQuery } from "../app";
 
-export function recommendationQueryMatches(
+type Predicate = (item: IRecommendation) => boolean;
+
+export function queryToPredicate(
     query: IRecommendationQuery | undefined,
-    _item: IRecommendation,
-) {
+): Predicate {
     if (query == null) {
-        return true;
+        return () => true;
     }
 
-    // TODO: Handle query params
-    return true;
+    const predicates: Predicate[] = [];
+
+    const { excludeTypes } = query;
+    if (excludeTypes != null) {
+        const excludedSet = new Set(excludeTypes);
+        predicates.push((item) => !excludedSet.has(item.recommendationType));
+    }
+
+    return (item: IRecommendation) => {
+        return predicates.every((predicate) => predicate(item));
+    };
 }
 
 export default async function* filterRecommendations<T extends IRecommendation>(
     query: IRecommendationQuery | undefined,
     items: AsyncIterable<T>,
 ) {
+    const predicate = queryToPredicate(query);
     for await (const item of items) {
-        if (recommendationQueryMatches(query, item)) {
+        if (predicate(item)) {
             yield item;
         }
     }

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1,0 +1,5 @@
+export type CollectionItem<T> = T extends Array<infer I>
+    ? I
+    : T extends Set<infer I>
+    ? I
+    : never;

--- a/src/util/withRecommendationType.ts
+++ b/src/util/withRecommendationType.ts
@@ -1,0 +1,13 @@
+import { IQueryResult, RecommendationType } from "../app";
+
+export default async function* withRecommendationType<T extends IQueryResult>(
+    items: AsyncIterable<T>,
+    recommendationType: RecommendationType,
+): AsyncIterable<T & { recommendationType: RecommendationType }> {
+    for await (const item of items) {
+        yield {
+            ...item,
+            recommendationType,
+        };
+    }
+}

--- a/src/util/withRecommendationType.ts
+++ b/src/util/withRecommendationType.ts
@@ -1,8 +1,8 @@
 import { IQueryResult, RecommendationType } from "../app";
 
 export default async function* withRecommendationType<T extends IQueryResult>(
-    items: AsyncIterable<T>,
     recommendationType: RecommendationType,
+    items: AsyncIterable<T>,
 ): AsyncIterable<T & { recommendationType: RecommendationType }> {
     for await (const item of items) {
         yield {

--- a/test/util/filterRecommendations-test.ts
+++ b/test/util/filterRecommendations-test.ts
@@ -1,0 +1,35 @@
+import * as chai from "chai";
+
+import { IRecommendation, RecommendationType } from "../../src/app";
+import { queryToPredicate } from "../../src/util/filterRecommendations";
+
+chai.should();
+
+function ofType(recommendationType: RecommendationType): IRecommendation {
+    return {
+        appName: "testapp",
+        title: "Test",
+        recommendationType,
+        playable: () => {
+            throw new Error();
+        },
+    };
+}
+
+describe("queryToPredicate", () => {
+    it("supports the default query", () => {
+        const pred = queryToPredicate(undefined);
+        pred(ofType(RecommendationType.Recent)).should.be.true;
+        pred(ofType(RecommendationType.Saved)).should.be.true;
+        pred(ofType(RecommendationType.Popular)).should.be.true;
+    });
+
+    it("supports excluding types", () => {
+        const pred = queryToPredicate({
+            excludeTypes: [RecommendationType.Recent, RecommendationType.Saved],
+        });
+        pred(ofType(RecommendationType.Recent)).should.be.false;
+        pred(ofType(RecommendationType.Saved)).should.be.false;
+        pred(ofType(RecommendationType.Popular)).should.be.true;
+    });
+});


### PR DESCRIPTION
This PR deprecates the ambiguous old `queryRecommended` Channel API in favor of `queryRecent` and `queryRecommendation`. The former is very unambiguous and is nice and single-purpose. The latter *can* behave the same as the old `queryRecommended`, but provides tools for selecting specific recommendation types (specifically, you can *exclude* types that aren't of interest, like if you *only* want recommendations, you can exclude recently-watched) and also for inspecting *why* something was recommended.

Most sources currently still just return recently watched recommendations here, but a couple can already provide other types; future work can expand on support in this area.

Fixes #55

- Scaffold support for explicitly querying recent vs recommended media
- Update DisneyPlayerChannel to support recent vs recommended
- Update HboPlayerChannel to support recent vs recommended
- Fill out remaining queryRecent impls matching queryRecommended
- plex: Unify some code
- Add new queryRecommendations interface; deprecate queryRecommended
- Add a shared util for respecting IRecommendationQuery
- Actually use the collection type -> recommendation info mapping
- Add (and support!) a basic `excludeTypes` query
