### PR TITLE
Fix DisneyApp support

### DIFF
--- a/src/apps/disney/api.ts
+++ b/src/apps/disney/api.ts
@@ -33,39 +33,41 @@ export type ImageTypes = CollectionItem<typeof IMAGE_TYPES>;
 const IMAGE_RATIOS = ["1.78", "1.33", "1.0", "0.75", "0.71", "0.67"] as const;
 export type ImageRatios = CollectionItem<typeof IMAGE_RATIOS>;
 
+type ResourceSet<
+    TopLevelTypes extends string,
+    Variants extends string,
+    Content,
+> = Partial<
+    Record<
+        TopLevelTypes,
+        {
+            [variant in Variants]: {
+                [key in SearchEntityType]: { default: Content };
+            };
+        }
+    >
+>;
+
 export interface ISearchHit {
     // Yeah, these got weird:
-    image: Record<
+    image: ResourceSet<
         ImageTypes,
-        Partial<{
-            [ratio in ImageRatios]: {
-                [key in SearchEntityType]: {
-                    default: {
-                        masterId: string;
-                        masterHeight: number;
-                        masterWidth: number;
-                        url: string;
-                    };
-                };
-            };
-        }>
+        ImageRatios,
+        {
+            masterId: string;
+            masterHeight: number;
+            masterWidth: number;
+            url: string;
+        }
     >;
-    text: Partial<
-        Record<
-            "title" | "description",
-            Record<
-                "full" | "slug",
-                {
-                    [key in SearchEntityType]: {
-                        default: {
-                            content: string;
-                            language: string;
-                            sourceEntity: key;
-                        };
-                    };
-                }
-            >
-        >
+    text: ResourceSet<
+        "title" | "description",
+        "full" | "slug",
+        {
+            content: string;
+            language: string;
+            sourceEntity: SearchEntityType;
+        }
     >;
 
     family?: {

--- a/src/apps/disney/api.ts
+++ b/src/apps/disney/api.ts
@@ -43,14 +43,24 @@ export interface ISearchHit {
             | "recap_end";
     }>;
 
-    texts: Array<{
-        content: string;
-        field: "description" | "title";
-        language: string;
-        sourceEntity: "series" | "program";
-        targetEntity: "series" | "program";
-        type: "brief" | "full" | "medium" | "slug" | "sort";
-    }>;
+    // Yeah, this got weird:
+    text: Partial<
+        Record<
+            "title" | "description",
+            Record<
+                "full" | "slug",
+                {
+                    [key: string]: {
+                        default: {
+                            content: string;
+                            language: string;
+                            sourceEntity: typeof key;
+                        };
+                    };
+                }
+            >
+        >
+    >;
 
     family?: {
         encodedFamilyId: string;
@@ -176,7 +186,12 @@ export class DisneyApi {
             query,
         });
 
-        debug("search hits=", disneysearch.hits);
+        debug(
+            "search hits=",
+            debug.enabled
+                ? JSON.stringify(disneysearch.hits, null, 2)
+                : disneysearch.hits,
+        );
         return disneysearch.hits.map(
             (obj: any) => obj.hit as ISearchHit,
         ) as ISearchHit[];

--- a/src/apps/disney/api.ts
+++ b/src/apps/disney/api.ts
@@ -18,6 +18,9 @@ const RESUME_SERIES_KEY = "ContinueWatchingSeries";
 
 const MIN_TOKEN_VALIDITY_MS = 5 * 60_000;
 
+/** `program` is used for eg movies, or episodes in a show */
+export type SearchEntityType = "program" | "series";
+
 export interface ISearchHit {
     images: Array<{
         purpose: string;
@@ -50,11 +53,11 @@ export interface ISearchHit {
             Record<
                 "full" | "slug",
                 {
-                    [key: string]: {
+                    [key in SearchEntityType]: {
                         default: {
                             content: string;
                             language: string;
-                            sourceEntity: typeof key;
+                            sourceEntity: key;
                         };
                     };
                 }

--- a/src/apps/disney/channel.ts
+++ b/src/apps/disney/channel.ts
@@ -25,6 +25,7 @@ const MOVIE_URL = "https://www.disneyplus.com/movies/";
 
 const RECOMMENDATION_SET_TYPES = new Set([
     "RecommendationSet",
+    "CuratedSet",
     "ContinueWatchingSet",
 ] as const);
 

--- a/src/apps/disney/channel.ts
+++ b/src/apps/disney/channel.ts
@@ -83,15 +83,8 @@ export class DisneyPlayerChannel implements IPlayerChannel<DisneyApp> {
         });
         if (!queryResult) return;
 
-        // TODO: ?
-        // const seriesTitleObj = episode.texts.find(
-        //     (text) =>
-        //         text.field === "title" &&
-        //         text.type === "full" &&
-        //         text.sourceEntity === "series",
-        // );
-        // const seriesTitle = seriesTitleObj ? seriesTitleObj.content : "";
-        const seriesTitle = "";
+        const seriesTitle =
+            episode.text.title?.full?.series?.default?.content ?? "";
 
         return {
             ...queryResult,
@@ -182,12 +175,11 @@ export class DisneyPlayerChannel implements IPlayerChannel<DisneyApp> {
         const isMovie = !isSeries && result.programType === "movie";
 
         const slugContainer = result.text?.title?.slug;
-        const textKey =
-            slugContainer == null ? undefined : Object.keys(slugContainer)[0];
-        if (textKey == null) {
-            debug("No full title key for", result);
+        if (slugContainer == null) {
+            debug("No slug for", result);
             return;
         }
+        const textKey = "program" in slugContainer ? "program" : "series";
 
         const titleObj = result.text.title?.full?.[textKey];
         const descObj = result.text.description?.full?.[textKey];

--- a/src/apps/disney/channel.ts
+++ b/src/apps/disney/channel.ts
@@ -204,9 +204,7 @@ export class DisneyPlayerChannel implements IPlayerChannel<DisneyApp> {
             url = PLAYBACK_URL + id;
         }
 
-        const imageContainer =
-            result.image?.tile ?? result.image?.background_detail;
-        const cover = pickPreferredImage(imageContainer, textKey)?.url;
+        const cover = pickPreferredImage(result.image, textKey)?.url;
 
         return {
             appName: "DisneyApp",

--- a/src/apps/disney/channel.ts
+++ b/src/apps/disney/channel.ts
@@ -14,7 +14,7 @@ import { mergeAsyncIterables } from "../../async";
 // NOTE: this sure looks like a circular dependency, but we're just
 // importing it for the type definition
 import type { DisneyApp, IDisneyOpts } from ".";
-import { DisneyApi, ICollection, ISearchHit } from "./api";
+import { DisneyApi, ICollection, ISearchHit, pickPreferredImage } from "./api";
 import filterRecommendations from "../../util/filterRecommendations";
 
 const debug = _debug("babbling:DisneyApp:channel");
@@ -204,8 +204,13 @@ export class DisneyPlayerChannel implements IPlayerChannel<DisneyApp> {
             url = PLAYBACK_URL + id;
         }
 
+        const imageContainer =
+            result.image?.tile ?? result.image?.background_detail;
+        const cover = pickPreferredImage(imageContainer, textKey)?.url;
+
         return {
             appName: "DisneyApp",
+            cover,
             desc: descObj ? descObj.default.content : undefined,
             title: titleObj.default.content,
             url,

--- a/src/apps/disney/channel.ts
+++ b/src/apps/disney/channel.ts
@@ -181,9 +181,10 @@ export class DisneyPlayerChannel implements IPlayerChannel<DisneyApp> {
         const sourceEntity =
             isMovie || (isSeries && playEpisodeDirectly) ? "program" : null;
 
-        const filteredTexts = result.texts.filter(
-            (item) => !sourceEntity || item.sourceEntity === sourceEntity,
-        );
+        const filteredTexts =
+            result.texts?.filter(
+                (item) => !sourceEntity || item.sourceEntity === sourceEntity,
+            ) ?? [];
         const titleObj = filteredTexts.find(
             (item) => item.field === "title" && item.type === "full",
         );

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1,4 +1,4 @@
-export type CollectionItem<T> = T extends Array<infer I>
+export type CollectionItem<T> = T extends ReadonlyArray<infer I>
     ? I
     : T extends Set<infer I>
     ? I


### PR DESCRIPTION
Turns out more broke in the DisneyApp support than just reading the tokens. They changed the API quite a bit. This PR updates our code to handle those changes, and enhances some results such as including cover art.

- WIP: Update graphql query formatting
- Update search hit types and parsing
- Update seriesTitle extraction
- Return cover art for search hits
- Restore episode search functionality + expand cover art support
- Restore collection loading + add extra recommendation context
- Include curated sets in disney recommendations
